### PR TITLE
Auto-leveling and probe file load/saving fixes

### DIFF
--- a/CNC.py
+++ b/CNC.py
@@ -807,7 +807,9 @@ class CNC:
 				self.processPath(cmds)
 				xyz = self.motionPath(True)
 				if not xyz:
-					newlines.append(None)
+					# while autolevelling, do not ignore non-movement lines
+					# so just append the line as-is
+					newlines.append(line)
 					continue
 				if self.gcode in (1,2,3):
 					for c in cmds:

--- a/bCNC.py
+++ b/bCNC.py
@@ -2019,11 +2019,15 @@ class Application(Toplevel):
 
 	#----------------------------------------------------------------------
 	def loadProbeDialog(self, event=None):
+		try:
+			pfilename = config.get("File", "probe")
+		except:
+			pfilename = "probe"
 		filename = bFileDialog.askopenfilename(master=self,
 			title="Open Probe file",
 			initialfile=os.path.join(
 					config.get("File", "dir"),
-					config.get("File", "probe")),
+					pfilename),
 			filetypes=[("Probe", ("*.probe")),
 				   ("All","*")])
 		if filename: self.loadProbe(filename)
@@ -2044,11 +2048,15 @@ class Application(Toplevel):
 
 	#----------------------------------------------------------------------
 	def saveProbeDialog(self, event=None):
+		try:
+			pfilename = config.get("File", "probe")
+		except:
+			pfilename = "probe"
 		filename = bFileDialog.asksaveasfilename(master=self,
 			title="Save probe file",
 			initialfile=os.path.join(
 					config.get("File", "dir"),
-					config.get("File", "probe")),
+					pfilename),
 			filetypes=[("G-Code",("*.ngc","*.nc", "*.gcode")),
 				   ("Probe", ("*.probe")),
 				   ("All","*")])


### PR DESCRIPTION
Hi,
this pull request fixes two issues:

1. While auto-leveling, the current code ignores non-movement lines, e.g. F200, M3/M5, etc. This fixes it.
2. The default bCNC.ini, which is used in new installations, does not contain a 'probe' option in the 'File' section which raises an exception in profile file saving/loading. This is also fixed by catching the exception and using a default value in this case. Although bCNC.ini should be updated also to contain this File->probe option so no exception is raised in new installations :)

Thanks for this great tool :)
:+1: 