### PR TITLE
Don't convert numbers after G, T, M or N commands.

### DIFF
--- a/CNC.py
+++ b/CNC.py
@@ -1442,6 +1442,9 @@ class GCode:
 			new.clear()
 			for cmd in cmds:
 				c = cmd[0].upper()
+				if c in ['G', 'T', 'M', 'N']:
+					new[c] = cmd[1:]
+					continue
 				try:
 					new[c] = float(cmd[1:])
 				except:
@@ -1454,7 +1457,10 @@ class GCode:
 				for cmd in cmds:
 					c = cmd[0].upper()
 					old[c] = new[c]
-					newcmd.append(self.fmt(cmd[0],new[c]))
+					if c in ['G', 'T', 'M', 'N']:
+						newcmd.append("%s%s" % (cmd[0],new[c]))
+					else:
+						newcmd.append(self.fmt(cmd[0],new[c]))
 				undoinfo.append(self.setLineUndo(bid,lid," ".join(newcmd)))
 
 		# XXX should I add it here or return it to be added later?


### PR DESCRIPTION
Grbl sends a "command unsupported" error for a G1. or G0. command. This happened, when bCNC 'moved' the gcode.

Signed-off-by: Omar Abo-Namous <kontakt@toomuchcookies.net>