### PR TITLE
Remove unnecessary open of tab Terminal

### DIFF
--- a/bCNC.py
+++ b/bCNC.py
@@ -3024,8 +3024,7 @@ class Application(Toplevel):
 		self.tabPage.changePage("Terminal")
 
 	def checkGcode(self):
-		self.send("$C\n")
-		self.tabPage.changePage("Terminal")
+		self.send("$C\n")		
 
 	def grblhelp(self):
 		self.send("$\n")


### PR DESCRIPTION
in case of enabling "Check GCode".
The status "check" is always visible in the status display.