### PR TITLE
Updated POSPAT to work with latest GRBL

### DIFF
--- a/bCNC.py
+++ b/bCNC.py
@@ -67,7 +67,7 @@ MAX_HISTORY  = 500
 GPAT     = re.compile(r"[A-Za-z]\d+.*")
 LINEPAT  = re.compile(r"^(.*?)\n(.*)", re.DOTALL|re.MULTILINE)
 STATUSPAT= re.compile(r"^<(.*?),MPos:([+\-]?\d*\.\d*),([+\-]?\d*\.\d*),([+\-]?\d*\.\d*),WPos:([+\-]?\d*\.\d*),([+\-]?\d*\.\d*),([+\-]?\d*\.\d*)>$")
-POSPAT   = re.compile(r"^\[(...):([+\-]?\d*\.\d*),([+\-]?\d*\.\d*),([+\-]?\d*\.\d*):?(\d*)\]$")
+POSPAT   = re.compile(r"^\[(...):([+\-]?\d*\.\d*),([+\-]?\d*\.\d*),([+\-]?\d*\.\d*)[\:]?[0-9]*\]$")
 TLOPAT   = re.compile(r"^\[(...):([+\-]?\d*\.\d*)\]$")
 
 _LOWSTEP   = 0.0001


### PR DESCRIPTION
GRBL version 0.9i, reports the probed position report with ":[0-1]" tacked at the end. According the wiki:

(Grbl v0.9i or later) The :1 suffix value is a boolean that denotes whether the last probe cycle was successful or not.

Anyway, I changed the regex to work with this. As far as I can tell, the regex should be backwards compatible...