### PR TITLE
Serial port opening a little more robust

### DIFF
--- a/bCNC.py
+++ b/bCNC.py
@@ -3100,8 +3100,14 @@ class Application(Toplevel):
 	#----------------------------------------------------------------------
 	def open(self, device, baudrate):
 		try:
-			self.serial = serial.Serial(device,baudrate,timeout=0.1)
+			self.serial = serial.Serial(device,baudrate,timeout=0.1,bytesize=serial.EIGHTBITS,parity=serial.PARITY_NONE,stopbits=serial.STOPBITS_ONE,xonxoff=0,rtscts=0)
+			# Toggle DTR to reset Arduino
+			self.serial.setDTR(False)
 			time.sleep(1)
+			# toss any data already received, see
+			# http://pyserial.sourceforge.net/pyserial_api.html#serial.Serial.flushInput
+			self.serial.flushInput()
+			self.serial.setDTR(True)
 			self._pos["state"] = "Connected"
 			self._pos["color"] = STATECOLOR[self._pos["state"]]
 			self.state.config(text=self._pos["state"],


### PR DESCRIPTION
Sometimes I have trouble connecting to the serial port.
The only way I 've found to make this work again is to open the arduino ide serial monitor. This somehow resets correctly the port and I 'm then able to connect again with bCNC.

After some source digging and googling, I made this port opening a little more robust. It 's been working fine for me now for more than a month so I don't think any of the extra commands have any side effects.