### PR TITLE
fixed typo for /icon path in pendant

### DIFF
--- a/Pendant.py
+++ b/Pendant.py
@@ -33,7 +33,7 @@ port = 8080
 httpd = None
 prgpath = os.path.abspath(os.path.dirname(sys.argv[0]))
 webpath = "%s/pendant"%(prgpath)
-iconpath = "%s/icon/"%(prgpath)
+iconpath = "%s/icons/"%(prgpath)
 
 #==============================================================================
 # Simple Pendant controller for CNC


### PR DESCRIPTION
With the pendant started, type this address in a browser: http://localhost:8080/icon?name=start32
It will return an empty page.
With this commit, it will return the named icon (start32), as expected :)