### PR TITLE
Add mime-type to pendant for jpg and gif

### DIFF
--- a/Pendant.py
+++ b/Pendant.py
@@ -166,6 +166,8 @@ class Pendant(HTTPServer.BaseHTTPRequestHandler):
 		filetype = page.rpartition('.')[2]
 		if filetype == "css": self.do_HEAD(content="text/css")
 		elif filetype == "js": self.do_HEAD(content="text/javascript")
+		elif filetype == "jpg": self.do_HEAD(content="image/gif")
+		elif filetype == "gif": self.do_HEAD(content="image/javascript")
 		else: self.do_HEAD()
 
 		if page == "": page = "index.html"

--- a/Pendant.py
+++ b/Pendant.py
@@ -166,8 +166,8 @@ class Pendant(HTTPServer.BaseHTTPRequestHandler):
 		filetype = page.rpartition('.')[2]
 		if filetype == "css": self.do_HEAD(content="text/css")
 		elif filetype == "js": self.do_HEAD(content="text/javascript")
-		elif filetype == "jpg": self.do_HEAD(content="image/gif")
-		elif filetype == "gif": self.do_HEAD(content="image/javascript")
+		elif filetype == "jpg": self.do_HEAD(content="image/jpeg")
+		elif filetype == "gif": self.do_HEAD(content="image/gif")
 		else: self.do_HEAD()
 
 		if page == "": page = "index.html"

--- a/Pendant.py
+++ b/Pendant.py
@@ -165,9 +165,12 @@ class Pendant(HTTPServer.BaseHTTPRequestHandler):
 		#handle certain filetypes
 		filetype = page.rpartition('.')[2]
 		if filetype == "css": self.do_HEAD(content="text/css")
-		elif filetype == "js": self.do_HEAD(content="text/javascript")
-		elif filetype == "jpg": self.do_HEAD(content="image/jpeg")
+		elif filetype == "js": self.do_HEAD(content="application/x-javascript")
+		elif filetype == "json": self.do_HEAD(content="application/json")
+		elif filetype == "jpg" or filetype == "jpeg" : self.do_HEAD(content="image/jpeg")
 		elif filetype == "gif": self.do_HEAD(content="image/gif")
+		elif filetype == "png": self.do_HEAD(content="image/png")
+		elif filetype == "ico": self.do_HEAD(content="image/x-icon")
 		else: self.do_HEAD()
 
 		if page == "": page = "index.html"


### PR DESCRIPTION
I have a webcam setup that takes snapshots. I integrated it into the pendant html, but by default baseHTTP in Python returns the jpg with a text/html.
Corrected this based on file extension jpg (and added gif while I was at it, could possibly do more types like png etc.)