### PR TITLE
Add PyCharm's metadata directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 lib/*.pyc
+.idea


### PR DESCRIPTION
Small nicety, so people debugging with PyCharm don't have to keep manually excluding the metadata directory from git. ;)