### PR TITLE
Text input field in plugin tools was not packed correctly.

### DIFF
--- a/lib/tkExtra.py
+++ b/lib/tkExtra.py
@@ -2522,6 +2522,7 @@ class InPlaceText(InPlaceEdit):
 	def createWidget(self):
 		self.toplevel = Toplevel(self.listbox)
 		self.toplevel.transient(self.listbox)
+		self.toplevel.update_idletasks() 
 		self.toplevel.overrideredirect(1)
 		self.edit = Text(self.toplevel, width=70, height=10,
 					background="White", undo=True)


### PR DESCRIPTION
At least in windows OS the input field was not visible. With this is still visible a small flicker when click on the the field. Better than nothing.. any improvement is welcome.