### PR TITLE
Adds a "Set WPOS" action to the canvas and keyboard shortcuts for jogging

### DIFF
--- a/CNCCanvas.py
+++ b/CNCCanvas.py
@@ -73,6 +73,7 @@ ACTION_ORIGIN        = 11
 ACTION_MOVE          = 20
 ACTION_ROTATE        = 21
 ACTION_GANTRY        = 22
+ACTION_SET_POS       = 23
 
 ACTION_RULER         = 30
 
@@ -110,6 +111,7 @@ MOUSE_CURSOR = {
 	ACTION_MOVE          : "hand1",
 	ACTION_ROTATE        : "exchange",
 	ACTION_GANTRY        : "target",
+	ACTION_SET_POS        : "target",
 
 	ACTION_RULER         : "tcross",
 
@@ -276,6 +278,11 @@ class CNCCanvas(Canvas):
 		self.event_generate("<<Status>>",data=_("Move CNC gantry to mouse location"))
 
 	# ----------------------------------------------------------------------
+	def setActionSetPos(self, event=None):
+		self.setAction(ACTION_SET_POS)
+		self.event_generate("<<Status>>",data=_("Set mouse location as current machine position (X/Y only)"))
+
+	# ----------------------------------------------------------------------
 	def setActionRuler(self, event=None):
 		self.setAction(ACTION_RULER)
 		self.event_generate("<<Status>>",data=_("Drag a ruler to measure distances"))
@@ -307,6 +314,16 @@ class CNCCanvas(Canvas):
 
 		elif self.view == VIEW_ISO3:
 			self.app.goto(-0.5*(u/S60+v/C60), -0.5*(u/S60-v/C60))
+		self.setAction(ACTION_SELECT)
+
+	# ----------------------------------------------------------------------
+	def actionSetPos(self, x, y):
+		u = self.canvasx(x) / self.zoom
+		v = self.canvasy(y) / self.zoom
+
+		if self.view == VIEW_XY:
+			self.app.dro.wcsSet(u,-v, None)
+
 		self.setAction(ACTION_SELECT)
 
 	# ----------------------------------------------------------------------
@@ -373,6 +390,9 @@ class CNCCanvas(Canvas):
 		# Move gantry to position
 		elif self.action == ACTION_GANTRY:
 			self.actionGantry(event.x,event.y)
+		# Move gantry to position
+		elif self.action == ACTION_SET_POS:
+			self.actionSetPos(event.x,event.y)
 
 		# Set coordinate origin
 		elif self.action == ACTION_ORIGIN:
@@ -1476,6 +1496,15 @@ class CanvasFrame(Frame):
 					value=ACTION_GANTRY,
 					command=self.canvas.setActionGantry)
 		tkExtra.Balloon.set(b, _("Move gantry [G]"))
+		self.addWidget(b)
+		b.pack(side=LEFT)
+
+		b = Radiobutton(toolbar, image=Utils.icons["origin"],
+					indicatoron=FALSE,
+					variable=self.canvas.actionVar,
+					value=ACTION_SET_POS,
+					command=self.canvas.setActionSetPos)
+		tkExtra.Balloon.set(b, _("Set WPOS"))
 		self.addWidget(b)
 		b.pack(side=LEFT)
 

--- a/ControlPage.py
+++ b/ControlPage.py
@@ -513,6 +513,22 @@ class ControlFrame(CNCRibbon.PageLabelFrame):
 		except:
 			self.zstep = self.step
 
+		# Default steppings
+		try:
+			self.step1 = Utils.getFloat("Control","step1")
+		except:
+			self.step1 = 0.1
+
+		try:
+			self.step2 = Utils.getFloat("Control","step2")
+		except:
+			self.step2 = 1
+
+		try:
+			self.step3 = Utils.getFloat("Control","step3")
+		except:
+			self.step3 = 10
+
 		# ---
 		row += 1
 		col = 0
@@ -708,6 +724,15 @@ class ControlFrame(CNCRibbon.PageLabelFrame):
 			zs=None
 		self.setStep(s, zs)
 
+
+	def setStep1(self, event=None):
+		self.setStep(self.step1, self.step1)
+
+	def setStep2(self, event=None):
+		self.setStep(self.step2, self.step2)
+
+	def setStep3(self, event=None):
+		self.setStep(self.step3, self.step2)
 #===============================================================================
 # StateFrame
 #===============================================================================

--- a/ControlPage.py
+++ b/ControlPage.py
@@ -326,6 +326,10 @@ class DROFrame(CNCRibbon.PageFrame):
 		self._wcsSet(None,None,self.zwork.get())
 
 	#----------------------------------------------------------------------
+	def wcsSet(self, x, y, z):
+		self._wcsSet(x, y, z)
+
+	#----------------------------------------------------------------------
 	def _wcsSet(self, x, y, z):
 		global wcsvar
 		p = wcsvar.get()

--- a/bCNC.ini
+++ b/bCNC.ini
@@ -33,7 +33,10 @@ errorreport = 1
 [Control]
 step = 1
 wcs = 54
-#zstep = 1
+zstep = 1
+step1=0.1
+step2=1
+step2=10
 
 [Canvas]
 view = X-Y

--- a/bCNC.ini
+++ b/bCNC.ini
@@ -36,7 +36,7 @@ wcs = 54
 zstep = 1
 step1=0.1
 step2=1
-step2=10
+step3=10
 
 [Canvas]
 view = X-Y

--- a/bCNC.py
+++ b/bCNC.py
@@ -358,6 +358,10 @@ class Application(Toplevel,Sender):
 		self.bind('<Key-slash>',	self.control.divStep)
 		self.bind('<KP_Divide>',	self.control.divStep)
 
+		self.bind('<Key-1>',	self.control.setStep1)
+		self.bind('<Key-2>',	self.control.setStep2)
+		self.bind('<Key-3>',	self.control.setStep3)
+
 		self.bind('<Key-exclam>',	self.feedHold)
 		self.bind('<Key-asciitilde>',	self.resume)
 


### PR DESCRIPTION
Sometimes it is helpful to be able to align the machine to an existing distinct point or egde and then update the WPOS according to this known position. This adds an action which lets the user click on a known point to update the WPOS.

It also adds key bindings to "1", "2" and "3" to set three pre defined common step widths (0.1 1 10 by default).