### PR TITLE
Proposal to open the user's configuration file.

### DIFF
--- a/ToolsPage.py
+++ b/ToolsPage.py
@@ -1135,6 +1135,18 @@ class ConfigGroup(CNCRibbon.ButtonGroup):
 		tkExtra.Balloon.set(b, _("Shortcuts"))
 		self.addWidget(b)
 
+		row += 1
+		b = Button(self.frame,
+				image=Utils.icons["about"],
+				text=_("User File"),
+				compound=LEFT,
+				anchor=W,
+				command=app.showUserFile,
+				background=Ribbon._BACKGROUND)
+		b.grid(row=row, column=col, padx=0, pady=0, sticky=NSEW)
+		tkExtra.Balloon.set(b, _("Open user configuration file"))
+		self.addWidget(b)
+
 #==============================================================================
 # Tools Frame
 #==============================================================================

--- a/bCNC.py
+++ b/bCNC.py
@@ -497,6 +497,12 @@ class Application(Toplevel,Sender):
 				self.bind("<%s>"%(key), lambda e,s=self,c=value : s.execute(c))
 
 	#-----------------------------------------------------------------------
+	def showUserFile(self):
+		import webbrowser
+		webbrowser.open(Utils.iniUser)
+		#os.startfile(Utils.iniUser)
+
+	#-----------------------------------------------------------------------
 	def loadConfig(self):
 		global geometry
 		if geometry is None:


### PR DESCRIPTION
To avoid always the mismatch between bCNC.ini file and user .bCNC file when asking for the configuration file.
It's just a draft. I've tested only in windows with a machine with already associated .bCNC files.