### PR TITLE
Update bCNC.po, see https://github.com/vlachoudis/bCNC/issues/153

### DIFF
--- a/locale/fr/LC_MESSAGES/bCNC.po
+++ b/locale/fr/LC_MESSAGES/bCNC.po
@@ -1748,7 +1748,7 @@ msgstr "SEULEMENT avant sondage"
 
 #: ProbePage.py:39
 msgid "BEFORE & AFTER probing"
-msgstr "AVANT & APRÈS sondage"
+msgstr "AVANT & APRES sondage"
 
 #: ProbePage.py:54 ProbePage.py:262 ProbePage.py:284 bCNC.py:90
 msgid "Probe"


### PR DESCRIPTION
The "È" char doesn't seems to be part of unicode.