### PR TITLE
Camera in canvas prevent program to be closed

### DIFF
--- a/bCNC.py
+++ b/bCNC.py
@@ -465,6 +465,7 @@ class Application(Toplevel,Sender):
 		if self.fileModified():
 			return
 
+		self.canvas.cameraOff()
 		Sender.quit(self)
 		self.saveConfig()
 		self.destroy()


### PR DESCRIPTION
At least in windows, if you let camera turned on in canvas, bcnc doesn't close nicely. The GUI close but the python prompt stay there forever.
@vlachoudis there could be better way to handle this. This is just for reference.