### PR TITLE
Fix in sending overrided zero feed

### DIFF
--- a/Sender.py
+++ b/Sender.py
@@ -773,12 +773,12 @@ class Sender:
 					if CNC.vars["overrideChanged"]:
 						CNC.vars["overrideChanged"] = False
 						self._newFeed = float(self._lastFeed)*CNC.vars["override"]/100.0
-						if pat is None:
+						if pat is None and self._newFeed!=0:
 							tosend = "f%g" % (self._newFeed) + tosend
 							#print tosend
 
 					#Apply override Feed
-					if CNC.vars["override"] != 100:
+					if CNC.vars["override"] != 100 and self._newFeed!=0:
 						pat = FEEDPAT.match(tosend)
 						if pat is not None:
 							try:


### PR DESCRIPTION
I've added the bug, now it should be fixed.
It happened when setting overrride before streaming anything, so it try to send a zero speed feed. That's no good.
