### PR TITLE
DRO zero padding

### DIFF
--- a/CNC.py
+++ b/CNC.py
@@ -647,6 +647,7 @@ class CNC:
 	stdexpr        = False	# standard way of defining expressions with []
 	comment        = ""	# last parsed comment
 	developer      = False
+	drozeropad     = 0
 	vars           = {
 			"prbx"      : 0.0,
 			"prby"      : 0.0,
@@ -769,6 +770,8 @@ class CNC:
 		try: CNC.accuracy       = float(config.get(section, "accuracy"))
 		except: pass
 		try: CNC.digits         = int(  config.get(section, "round"))
+		except: pass
+		try: CNC.drozeropad     = int(  config.get(section, "drozeropad"))
 		except: pass
 
 		CNC.startup = config.get(section, "startup")

--- a/ControlPage.py
+++ b/ControlPage.py
@@ -309,13 +309,16 @@ class DROFrame(CNCRibbon.PageFrame):
 			focus = self.focus_get()
 		except:
 			focus = None
-		if focus is not self.xwork: self.xwork.set(CNC.vars["wx"])
-		if focus is not self.ywork: self.ywork.set(CNC.vars["wy"])
-		if focus is not self.zwork: self.zwork.set(CNC.vars["wz"])
+		if focus is not self.xwork:
+			self.xwork.set("%0.*f"%(CNC.drozeropad,CNC.vars["wx"]))
+		if focus is not self.ywork:
+			self.ywork.set("%0.*f"%(CNC.drozeropad,CNC.vars["wy"]))
+		if focus is not self.zwork:
+			self.zwork.set("%0.*f"%(CNC.drozeropad,CNC.vars["wz"]))
 
-		self.xmachine["text"] = CNC.vars["mx"]
-		self.ymachine["text"] = CNC.vars["my"]
-		self.zmachine["text"] = CNC.vars["mz"]
+		self.xmachine["text"] = "%0.*f"%(CNC.drozeropad,CNC.vars["mx"])
+		self.ymachine["text"] = "%0.*f"%(CNC.drozeropad,CNC.vars["my"])
+		self.zmachine["text"] = "%0.*f"%(CNC.drozeropad,CNC.vars["mz"])
 
 	#----------------------------------------------------------------------
 	# Do not give the focus while we are running

--- a/ToolsPage.py
+++ b/ToolsPage.py
@@ -500,6 +500,7 @@ class CNC(_Base):
 			("startup"       , "str" , "G90", _("Start up"))          ,
 			("spindlemin"    , "int" , 0    , _("Spindle min (RPM)")),
 			("spindlemax"    , "int" , 12000, _("Spindle max (RPM)")),
+			("drozeropad"    , "int" , 0    , _("DRO Zero padding")),
 			("header"        , "text" ,   "", _("Header gcode")),
 			("footer"        , "text" ,   "", _("Footer gcode"))
 		]


### PR DESCRIPTION
As point out by @tklus in #345 it wolud be nice to customize the padding of the DRO.  
Like here I believe: 

![image](https://cloud.githubusercontent.com/assets/1007007/15798781/7a13f818-2a45-11e6-8b4d-02f921b56ca6.png)

The settings will be set here (Tools->Machine->DRO Zero padding): 

![image](https://cloud.githubusercontent.com/assets/1007007/15798784/adba9d8e-2a45-11e6-807a-56b1e0abe184.png)

Then restart bCNC to take effect.