### PR TITLE
Input Wpos from Float Entry

### DIFF
--- a/ControlPage.py
+++ b/ControlPage.py
@@ -349,19 +349,17 @@ class DROFrame(CNCRibbon.PageFrame):
 	#----------------------------------------------------------------------
 	def setX(self, event=None):
 		if self.app.running: return
-		self._wcsSet(self.xwork.get(),None,None)
+		self._wcsSet(self.xwork.getfloat(),None,None)
 
 	#----------------------------------------------------------------------
 	def setY(self, event=None):
 		if self.app.running: return
-		self.sendGCode(cmd)
-		self.sendGCode("$#")
-		self._wcsSet(None,self.ywork.get(),None)
+		self._wcsSet(None,self.ywork.getfloat(),None)
 
 	#----------------------------------------------------------------------
 	def setZ(self, event=None):
 		if self.app.running: return
-		self._wcsSet(None,None,self.zwork.get())
+		self._wcsSet(None,None,self.zwork.getfloat())
 
 	#----------------------------------------------------------------------
 	def wcsSet(self, x, y, z):

--- a/lib/tkExtra.py
+++ b/lib/tkExtra.py
@@ -387,14 +387,14 @@ class _ValidatingEntry(Entry):
 	# ----------------------------------------------------------------------
 	def getint(self, default=0):
 		try:
-			return int(self.get())
+			return int(eval(self.get()))
 		except:
 			return default
 
 	# ----------------------------------------------------------------------
 	def getfloat(self, default=0.0):
 		try:
-			return float(self.get())
+			return float(eval(self.get()))
 		except:
 			return default
 
@@ -441,6 +441,11 @@ class FloatEntry(_ValidatingEntry):
 	"""accept only floating point numbers"""
 	# ----------------------------------------------------------------------
 	def validate(self, value):
+		try:
+			if value: float(eval(value+"1"))
+			return True
+		except:
+			pass
 		try:
 			if value: float(value)
 			return True


### PR DESCRIPTION
Dirty attempt to allow user input some calculation in the WPOS input fields.

Looking at the code I've notice that the **setY** method in ControlPage.py was wrong (maybe some test left behind?)

Also, during the input the **HOME** key is not disabled. Probably  this should be avoid or it'll start the Home procedure instead of changing the caret position.

![image](https://cloud.githubusercontent.com/assets/1007007/16964752/66d75278-4dfd-11e6-95b7-7b2c0e54bbcc.png)
