### PR TITLE
Fix again InPlaceText in windows

### DIFF
--- a/lib/tkExtra.py
+++ b/lib/tkExtra.py
@@ -2610,6 +2610,7 @@ class InPlaceText(InPlaceEdit):
 	def createWidget(self):
 		self.toplevel = Toplevel(self.listbox)
 		self.toplevel.transient(self.listbox)
+		self.toplevel.update_idletasks() 
 		self.toplevel.overrideredirect(1)
 		self.edit = Text(self.toplevel, width=70, height=10,
 					background="White", undo=True)


### PR DESCRIPTION
In windows the self.toplevel.update_idletasks()  is needed. Otherwise the edit field is not visibile, even if it records any keystroke.
It was already committed here https://github.com/vlachoudis/bCNC/commit/9c0c5020e5ce6d53e6f3ee5dda48c4981a6b5723

Is there any problem with this in Linux?