### PR TITLE
Master vasilis save as

### DIFF
--- a/CNC.py
+++ b/CNC.py
@@ -2281,6 +2281,20 @@ class GCode:
 		self._lastModified = os.stat(self.filename).st_mtime
 		self._modified = False
 		return True
+		
+	#----------------------------------------------------------------------
+	# Save in TXT format (clened from bCNC tags)
+	#----------------------------------------------------------------------
+	def saveTXT(self, filename):
+		txt = open(filename, 'w')
+		for block in self.blocks:
+			if block.enable:
+				for line in block:
+					cmds = CNC.parseLine(line)
+					if cmds is None: continue
+					txt.write("%s\n"%line)
+		txt.close()
+		return True
 
 	#----------------------------------------------------------------------
 	def addBlockFromString(self, name, text):

--- a/CNC.py
+++ b/CNC.py
@@ -2283,7 +2283,10 @@ class GCode:
 		return True
 		
 	#----------------------------------------------------------------------
-	# Save in TXT format (clened from bCNC tags)
+	# Save in TXT format 
+	# -Enabled Blocks only
+	# -Clened from bCNC metadata and comments
+	# -Uppercase
 	#----------------------------------------------------------------------
 	def saveTXT(self, filename):
 		txt = open(filename, 'w')
@@ -2292,7 +2295,7 @@ class GCode:
 				for line in block:
 					cmds = CNC.parseLine(line)
 					if cmds is None: continue
-					txt.write("%s\n"%line)
+					txt.write("%s\n"%line.upper())
 		txt.close()
 		return True
 

--- a/Sender.py
+++ b/Sender.py
@@ -411,6 +411,9 @@ class Sender:
 			self.gcode.probe.saveAsSTL(filename)
 		elif ext == ".dxf":
 			return self.gcode.saveDXF(filename)
+		elif ext == ".txt":
+			#save gcode as txt (only enable blocks and no bCNC tags)
+			return self.gcode.saveTXT(filename)
 		else:
 			if filename is not None:
 				self.gcode.filename = filename

--- a/Sender.py
+++ b/Sender.py
@@ -412,7 +412,7 @@ class Sender:
 		elif ext == ".dxf":
 			return self.gcode.saveDXF(filename)
 		elif ext == ".txt":
-			#save gcode as txt (only enable blocks and no bCNC tags)
+			#save gcode as txt (only enable blocks and no bCNC metadata)
 			return self.gcode.saveTXT(filename)
 		else:
 			if filename is not None:

--- a/bCNC.py
+++ b/bCNC.py
@@ -86,6 +86,7 @@ MAX_HISTORY  = 500
 
 FILETYPES = [	(_("All accepted"), ("*.ngc","*.nc", "*.tap", "*.gcode", "*.dxf", "*.probe", "*.orient", "*.stl")),
 		(_("G-Code"),("*.ngc","*.nc", "*.tap", "*.gcode")),
+		(_("G-Code clean"),("*.txt")),
 		("DXF",       "*.dxf"),
 		("SVG",       "*.svg"),
 		(_("Probe"),  "*.probe"),


### PR DESCRIPTION
Save as txt:
- Without bCNC metadata
- Enabled blocks only
- Commands line only
- Uppercase

Should we add a new Save Dialog as proposed by @onekk ?