### PR TITLE
Automatically clear connected message.

### DIFF
--- a/Sender.py
+++ b/Sender.py
@@ -841,6 +841,9 @@ class Sender:
 						status = False
 						if not self._alarm:
 							CNC.vars["state"] = pat.group(1)
+						elif  self._gcount > 2 and CNC.vars["state"] == CONNECTED:
+							# turn off alarm for connected status once a valid gcode event occurs
+							self._alarm = False
 						CNC.vars["mx"] = float(pat.group(2))
 						CNC.vars["my"] = float(pat.group(3))
 						CNC.vars["mz"] = float(pat.group(4))


### PR DESCRIPTION
Instead of having the user clear the connected message it is now done automatically when a valid operation is sent to grbl, ie jogging the machine, selecting run/start.
This also corrects problems with run/idle not displaying when connected is displayed.  If the user doesn't clear the connected status message, or select stop or hard reset, then it always stays displayed.  
This also fixes a bug with pause/resume when connected message is displayed - pause would work the first time selected but selecting pause button to do a resume would not work.  Very annoying when using the pendant feature on a tablet since you have to type in resume as a command the first time.