### PR TITLE
Trying to get an infrastructure for multiple configuration files

### DIFF
--- a/ControlPage.py
+++ b/ControlPage.py
@@ -26,10 +26,27 @@ import CNCRibbon
 from Sender import ERROR_CODES
 from CNC import WCS, DISTANCE_MODE, FEED_MODE, UNITS, PLANE
 
-_LOWSTEP   = 0.0001
-_HIGHSTEP  = 1000.0
-_HIGHZSTEP = 10.0
 
+try:
+	_LOWSTEP = min(map(float, Utils.config.get("Control","steplist").split()))
+except:
+	_LOWSTEP   = 0.0001
+
+try:
+	_HIGHSTEP = max(map(float, Utils.config.get("Control","steplist").split()))
+except:
+	_HIGHSTEP  = 1000.0
+	
+try:
+	_LOWZSTEP = min(map(float, Utils.config.get("Control","zsteplist").split()))
+except:
+	_LOWZSTEP   = 0.0001
+
+try:
+	_HIGHZSTEP = max(map(float, Utils.config.get("Control","zsteplist").split()))
+except:
+	_HIGHZSTEP  = 1000.0
+	
 #===============================================================================
 # Connection Group
 #===============================================================================

--- a/Utils.py
+++ b/Utils.py
@@ -86,6 +86,10 @@ GRBL       = 0
 SMOOTHIE   = 1
 CONTROLLER = {"Grbl":0, "Smoothie":1}
 
+
+# Variable that holds all the configuration in form of a multi leve dictionary
+glb_data = {}
+
 #------------------------------------------------------------------------------
 def loadIcons():
 	global icons
@@ -109,7 +113,7 @@ def delIcons():
 # Load configuration
 #------------------------------------------------------------------------------
 def loadConfiguration(systemOnly=False):
-	global config, _errorReport, language
+	global config, _errorReport, language, glb_data
 	if systemOnly:
 		config.read(iniSystem)
 	else:
@@ -121,7 +125,15 @@ def loadConfiguration(systemOnly=False):
 			# replace language
 			__builtin__._ = gettext.translation('bCNC', os.path.join(prgpath,'locale'),
 					fallback=True, languages=[language]).gettext
-
+	
+	atest = read_ini_file("buttons.ini")
+	if atest is not "KO":
+		for k,v in glb_data.iteritems():
+			print k
+			for sk,sv in v.iteritems():
+				print sk," => ",sv
+			
+																																						
 #------------------------------------------------------------------------------
 # Save configuration file
 #------------------------------------------------------------------------------
@@ -154,6 +166,37 @@ def cleanConfiguration():
 				pass
 	config = newconfig
 
+#----------------------------------------------------------------------
+# define the order of the search path for ini files:
+# first the files in .config/bCNC
+# second the files in ~
+# third the file in the program dir
+# more patch can be added or a if condition based on OS type can be useful
+#----------------------------------------------------------------------
+def search_paths(file_name):
+	paths = map(lambda path: os.path.join(path, file_name),("~/.config/%s"%(__prg__),'~','./'),)
+	for path in paths:
+		f_path = os.path.expanduser(path)
+		print "Searching : ", f_path
+		if os.path.isfile(f_path):
+			return f_path	
+
+def read_ini_file(f_name):
+	global glb_data
+	inifile = search_paths(f_name)
+	if inifile:
+		config = ConfigParser.SafeConfigParser()
+		config.read(inifile)
+		for section in config.sections():
+			print "parsing section :",section
+			kdict = {}
+			kdict = dict(config.items(section))
+			glb_data[str(section)] = kdict
+		return "OK: %s "%(inifile)
+	else:
+		return "KO"												
+
+												
 #------------------------------------------------------------------------------
 # add section if it doesn't exist
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This is a first try to get an infrastructure for using multiple configuration files.

It define a global variable **glb_data** that holds a dictionary containing the "sections" of the configuration file, that could be parsed at the end to rewrite the configuration file in the appropriate place.

the dictionary holds a dictionary with the sections containing in the value a sub-dictionary holding the name,value pairs

It search in multiple path defined in the search_paths, that can be modified to use multiple OS dependant paths

the order is important the first file found is used.

the dictionary is easy adressable with `Utils.glb_data["Section"][name]` to obtain the appropriate value.

It is rough but it could be useful as a start, in this manner each plugin could have is own ini file with the pattern plugin_name.ini maybe in  `~/.config/bCNC/` on Linux and %PROGRAMDATA%\bCNC on windows (if i didn't go wrong with the windows location)

Regards
