### PR TITLE
Bugfix: pause button would not resume if job paused (grbl 1.1)

### DIFF
--- a/bCNC.py
+++ b/bCNC.py
@@ -2298,7 +2298,7 @@ class Application(Toplevel,Sender):
 					CNC.vars["color"] = STATECOLOR["Alarm"]
 				else:
 					CNC.vars["color"] = STATECOLORDEF
-			self._pause = (state=="Hold")
+			self._pause = ("Hold" in state)
 			self.dro.updateState()
 			self.dro.updateCoords()
 			self.canvas.gantry(CNC.vars["wx"],


### PR DESCRIPTION
- The bug only occured with grbl 1.1 since it now reports **Hold:0** or **Hold:1** instead of **Hold** as in older grbl versions. The fix does not effect operation with grbl 0.9.