### PR TITLE
Fixed autoleveling for smoothieware (both freezes and G0 speeds)

### DIFF
--- a/CNC.py
+++ b/CNC.py
@@ -275,17 +275,22 @@ class Probe:
 		self.makeMatrix()
 		x = self.xmin
 		xstep = self._xstep
-		lines = ["G0Z%.4f"%(CNC.vars["safe"]),
+		lines = ["F%g"%(CNC.vars["feed"]),
+			 "G0Z%.4f"%(CNC.vars["safe"]),
 			 "G0X%.4fY%.4f"%(self.xmin, self.ymin)]
 		for j in range(self.yn):
 			y = self.ymin + self._ystep*j
 			for i in range(self.xn):
+				lines.append("F%g"%(CNC.vars["feed"]))
 				lines.append("G0Z%.4f"%(self.zmax))
 				lines.append("G0X%.4fY%.4f"%(x,y))
+ 				lines.append("%wait")
 				lines.append("%sZ%.4fF%g"%(CNC.vars["prbcmd"], self.zmin, CNC.vars["prbfeed"]))
+ 				lines.append("%wait")
 				x += xstep
 			x -= xstep
 			xstep = -xstep
+		lines.append("F%g"%(CNC.vars["feed"]))
 		lines.append("G0Z%.4f"%(self.zmax))
 		lines.append("G0X%.4fY%.4f"%(self.xmin,self.ymin))
 		return lines


### PR DESCRIPTION
You may be interested by this fix, which is aimed at a better cooperation with Smoothieware.
I think it should not impact other firmware.

The mesh leveling froze on the first probe (already in contact), but it works with an additional %wait.

Also, smoothie use the last feed ratio for its G0 moves (which is wrong). This makes the leveling extremely slow after the first probe (because probing redefines the F to a very low value). So I just added an explicit single-line F command to reset the "feed" value to the initial value before calling G0. I think it should have no effect on firmwares that handle G0 properly (at maximum machine speed, whatever current feed rate).