### PR TITLE
Fix bug where bCNC is sending f0.4$X

### DIFF
--- a/Sender.py
+++ b/Sender.py
@@ -964,7 +964,7 @@ class Sender:
 							CNC.vars["_OvChanged"] = False
 							self._newFeed = float(self._lastFeed)*CNC.vars["_OvFeed"]/100.0
 							if pat is None and self._newFeed!=0:
-								tosend = "f%g" % (self._newFeed) + tosend
+								tosend = "f%g\n" % (self._newFeed) + tosend
 
 						#Apply override Feed
 						if CNC.vars["_OvFeed"] != 100 and self._newFeed!=0:

--- a/Sender.py
+++ b/Sender.py
@@ -959,12 +959,12 @@ class Sender:
 					if pat is not None:
 						self._lastFeed = pat.group(2)
 
-					if self.controller in (Utils.GRBL0, Utils.SMOOTHIE):
+					if self.controller in (Utils.GRBL0, Utils.SMOOTHIE) and not tosend.startswith("$"):
 						if CNC.vars["_OvChanged"]:
 							CNC.vars["_OvChanged"] = False
 							self._newFeed = float(self._lastFeed)*CNC.vars["_OvFeed"]/100.0
 							if pat is None and self._newFeed!=0:
-								tosend = "f%g\n" % (self._newFeed) + tosend
+								tosend = "f%g" % (self._newFeed) + tosend
 
 						#Apply override Feed
 						if CNC.vars["_OvFeed"] != 100 and self._newFeed!=0:


### PR DESCRIPTION
This fixes a bug for me though I don't complete understand why.  The procedure to reproduce the bug for me:

1. Open bCNC, connect to router.
2. home, reset, unlock
3. Calibrate.  Let it complete or cancel mid way, doesn't matter.
4. Alternate between clicking on reset and unlock buttons.

The error "expected command letter" appears when unlock is pressed after reset.  If unlock is pressed again, then it doesn't happen.

It seems that bCNC is sending "f0.01$x" to the router.  I also see it if I try to tool change, in which case bCNC sends "f0.01$g".  This PR fixes the bug for me.

Let me know if you need more info.