### PR TITLE
Add fastfeed option for faster calibration and tool changes.

### DIFF
--- a/CNC.py
+++ b/CNC.py
@@ -1671,6 +1671,15 @@ class CNC:
 			lines.append("g53 g0 z[toolprobez]")
 
 			# fixed WCS
+			if CNC.vars["fastprbfeed"]:
+				prb_reverse = {"2": "4", "3": "5", "4": "2", "5": "3"}
+				CNC.vars["prbcmdreverse"] = (CNC.vars["prbcmd"][:-1] +
+							     prb_reverse[CNC.vars["prbcmd"][-1]])
+				currentFeedrate = CNC.vars["fastprbfeed"]
+				while currentFeedrate > CNC.vars["prbfeed"]:
+					lines.append("g91 [prbcmd] f%f z[-tooldistance]" % currentFeedrate)
+					lines.append("g91 [prbcmdreverse] f%f z[tooldistance]" % currentFeedrate)
+					currentFeedrate /= 10
 			lines.append("g91 [prbcmd] f[prbfeed] z[-tooldistance]")
 
 			if CNC.toolPolicy==2:

--- a/ProbePage.py
+++ b/ProbePage.py
@@ -201,6 +201,19 @@ class ProbeCommonFrame(CNCRibbon.PageFrame):
 		row = 0
 		col = 0
 
+		# ----
+		# Fast Probe Feed
+		Label(frame, text=_("Fast Probe Feed:")).grid(row=row, column=col, sticky=E)
+		col += 1
+		ProbeCommonFrame.fastProbeFeed = tkExtra.FloatEntry(frame, background="White", width=5)
+		ProbeCommonFrame.fastProbeFeed.grid(row=row, column=col, sticky=EW)
+		tkExtra.Balloon.set(ProbeCommonFrame.fastProbeFeed, _("Set initial probe feed rate for tool change and calibration"))
+		self.addWidget(ProbeCommonFrame.fastProbeFeed)
+
+		# ----
+		# Probe Feed
+		row += 1
+		col  = 0
 		Label(frame, text=_("Probe Feed:")).grid(row=row, column=col, sticky=E)
 		col += 1
 		ProbeCommonFrame.probeFeed = tkExtra.FloatEntry(frame, background="White", width=5)
@@ -257,6 +270,7 @@ class ProbeCommonFrame(CNCRibbon.PageFrame):
 	@staticmethod
 	def probeUpdate():
 		try:
+			CNC.vars["fastprbfeed"] = float(ProbeCommonFrame.fastProbeFeed.get())
 			CNC.vars["prbfeed"] = float(ProbeCommonFrame.probeFeed.get())
 			CNC.vars["prbcmd"]  = str(ProbeCommonFrame.probeCmd.get().split()[0])
 			return False
@@ -276,12 +290,14 @@ class ProbeCommonFrame(CNCRibbon.PageFrame):
 
 	#-----------------------------------------------------------------------
 	def saveConfig(self):
+		Utils.setFloat("Probe", "fastfeed", ProbeCommonFrame.fastProbeFeed.get())
 		Utils.setFloat("Probe", "feed", ProbeCommonFrame.probeFeed.get())
 		Utils.setFloat("Probe", "tlo",  ProbeCommonFrame.tlo.get())
 		Utils.setFloat("Probe", "cmd",  ProbeCommonFrame.probeCmd.get().split()[0])
 
 	#-----------------------------------------------------------------------
 	def loadConfig(self):
+		ProbeCommonFrame.fastProbeFeed.set(Utils.getFloat("Probe","fastfeed"))
 		ProbeCommonFrame.probeFeed.set(Utils.getFloat("Probe","feed"))
 		ProbeCommonFrame.tlo.set(      Utils.getFloat("Probe","tlo"))
 		cmd = Utils.getStr("Probe","cmd")
@@ -1608,6 +1624,15 @@ class ToolFrame(CNCRibbon.PageFrame):
 		lines.append("g53 g0 x[toolchangex] y[toolchangey]")
 		lines.append("g53 g0 x[toolprobex] y[toolprobey]")
 		lines.append("g53 g0 z[toolprobez]")
+		if CNC.vars["fastprbfeed"]:
+			prb_reverse = {"2": "4", "3": "5", "4": "2", "5": "3"}
+			CNC.vars["prbcmdreverse"] = (CNC.vars["prbcmd"][:-1] +
+						     prb_reverse[CNC.vars["prbcmd"][-1]])
+			currentFeedrate = CNC.vars["fastprbfeed"]
+			while currentFeedrate > CNC.vars["prbfeed"]:
+				lines.append("g91 [prbcmd] f%f z[-tooldistance]" % currentFeedrate)
+				lines.append("g91 [prbcmdreverse] f%f z[tooldistance]" % currentFeedrate)
+				currentFeedrate /= 10
 		lines.append("g91 [prbcmd] f[prbfeed] z[-tooldistance]")
 		lines.append("g4 p1")	# wait a sec
 		lines.append("%wait")

--- a/bCNC.ini
+++ b/bCNC.ini
@@ -90,6 +90,7 @@ ymax   = 100.0
 yn     = 5
 zmin   = -10.0
 zmax   = 5.0
+fastfeed  = 100.0
 feed   = 10.0
 tlo    = 0.0
 center = 10.0


### PR DESCRIPTION
Currently, the probe feed rate is used for tool changes, calibration, and autolevelling.  When autolevelling, it is useful to go slowly so that the tool doesn't damage the PCB surface.  But for tool change and calibration, the sensor is spring loaded and it's possible to move the tool toward the sensor much faster.

However, moving the tool too fast results in inaccurate results.  So instead, start with a fast probe, then back off and try again 10 times slower, over and over, until doing the slowest setting.  This allows for faster probing without sacrificing accuracy.

If the fast feed is unset or is less than or equal to the regular feed speed then this option will have no effect on operation.