### PR TITLE
Add functionality allowing one to specify camera settings via one's INI settings.

### DIFF
--- a/Camera.py
+++ b/Camera.py
@@ -41,10 +41,56 @@ class Camera:
 		if cv is None: return
 		self.prefix  = prefix
 		self.idx     = Utils.getInt("Camera", prefix)
+		self.props   = self._getCameraProperties(prefix)
 		self.camera  = None
 		self.image   = None
 		self.frozen  = None
 		self.imagetk = None
+
+	def _getCameraProperties(self, prefix):
+		""" Gather user-defined camera configuration properties
+
+		Allows user to specify parameters like::
+
+		    [Camera]
+		    aligncam_height = 640
+		    aligncam_width = 480
+
+		to adjust the capture settings of the 'aligncam' camera.
+
+		:param str prefix: Prefix to gather
+		:returns: Dictionary mapping property suffix with a 2-tuple of
+			a function defining the data type, and a CV_CAP_PROP
+			property.
+		"""
+		POSSIBLE_PROPERTIES = {
+			'height': (Utils.getInt, cv.cv.CV_CAP_PROP_FRAME_HEIGHT, ),
+			'width': (Utils.getInt, cv.cv.CV_CAP_PROP_FRAME_WIDTH, ),
+			'fps': (Utils.getInt, cv.cv.CV_CAP_PROP_FPS, ),
+			'codec': (Utils.getStr, cv.cv.CV_CAP_PROP_FOURCC, ),
+			'brightness': (Utils.getInt, cv.cv.CV_CAP_PROP_BRIGHTNESS, ),
+			'contrast': (Utils.getInt, cv.cv.CV_CAP_PROP_CONTRAST, ),
+			'saturation': (Utils.getInt, cv.cv.CV_CAP_PROP_SATURATION, ),
+			'hue': (Utils.getInt, cv.cv.CV_CAP_PROP_HUE, ),
+			'gain': (Utils.getInt, cv.cv.CV_CAP_PROP_GAIN, ),
+			'exposure': (Utils.getInt, cv.cv.CV_CAP_PROP_EXPOSURE, ),
+		}
+
+		UNSPECIFIED = object()
+		properties_set = {}
+
+		for key, data in POSSIBLE_PROPERTIES.items():
+			fn, prop = data
+			value = fn(
+				'Camera',
+				'_'.join([prefix, key]),
+				default=UNSPECIFIED
+			)
+
+			if value is not UNSPECIFIED:
+				properties_set[prop] = value
+
+		return properties_set
 
 	#-----------------------------------------------------------------------
 	def isOn(self):
@@ -55,6 +101,10 @@ class Camera:
 	def start(self):
 		if cv is None: return
 		self.camera = cv.VideoCapture(self.idx)
+
+		for prop_id, prop_value in self.props.items():
+			self.camera.set(prop_id, prop_value)
+
 		if self.camera is None: return
 		s, self.image = self.camera.read()
 		if not self.camera.isOpened():


### PR DESCRIPTION
This adds functionality allowing users to customize the capture settings of their attached webcam by setting specific INI properties.

I added this functionality because the camera I use for CNC alignment captures at a high-enough resolution by default that bCNC became unnecessarily slow.  What this feature provided for me was the ability to override the default capture resolution to set it at a more reasonable value.

Note that I've tested only the `height` and `width` properties specifically, and not all cameras support all provided properties.  The other properties are provided because the settings were in nearby documentation and adding the extra options was minimal effort. 

Cheers!