### PR TITLE
Fix Z when backing off the probe

### DIFF
--- a/ProbePage.py
+++ b/ProbePage.py
@@ -1690,7 +1690,7 @@ class ToolFrame(CNCRibbon.PageFrame):
 			currentFeedrate = CNC.vars["fastprbfeed"]
 			while currentFeedrate > CNC.vars["prbfeed"]:
 				lines.append("g91 [prbcmd] f%f z[-tooldistance]" % currentFeedrate)
-				lines.append("g91 [prbcmdreverse] f%f z[tooldistance]" % currentFeedrate)
+				lines.append("g90 [prbcmdreverse] f%f z[toolprobez]" % currentFeedrate)
 				currentFeedrate /= 10
 		lines.append("g91 [prbcmd] f[prbfeed] z[-tooldistance]")
 		lines.append("g4 p1")	# wait a sec


### PR DESCRIPTION
Pulling back [tooldistance] in relative mode may end at a coordinate
outside the working area. At least GRBL 1.1 will throw an alarm and there
is no way to reset it except closing the serial port and reconnecting (and
loosing microstep positioning by doing this).

This changes pulling back to the absolute Z position we know is good: [toolprobez].