### PR TITLE
Shortcuts translatable

### DIFF
--- a/ToolsPage.py
+++ b/ToolsPage.py
@@ -474,9 +474,47 @@ class Events(Ini):
 		Ini.__init__(self, master, "Events", "str")
 
 #------------------------------------------------------------------------------
-class Shortcut(Ini):
+class Shortcut(_Base):
 	def __init__(self, master):
-		Ini.__init__(self, master, "Shortcut", "str")
+		_Base.__init__(self, master, "Shortcut")
+		self.variables = [
+			("F1",		"str",	"help"	, _("F1")),
+			("F2",		"str",	"edit"	, _("F2")),
+			("F3",		"str",	"XY"	, _("F3")),
+			("F4",		"str",	"ISO1"	, _("F4")),
+			("F5",		"str",	"ISO2"	, _("F5")),
+			("F6",		"str",	"ISO3"	, _("F6")),
+			("F7",		"str",	""	, _("F7")),
+			("F8",		"str",	""	, _("F8")),
+			("F9",		"str",	""	, _("F9")),
+			("F10",		"str",	""	, _("F10")),
+			("F11",		"str",	""	, _("F11")),
+			("F12",		"str",	""	, _("F12")),
+			("Shift-F1",	"str",	""	, _("Shift-") + _("F1")),
+			("Shift-F2",	"str",	""	, _("Shift-") + _("F2")),
+			("Shift-F3",	"str",	""	, _("Shift-") + _("F3")),
+			("Shift-F4",	"str",	""	, _("Shift-") + _("F4")),
+			("Shift-F5",	"str",	""	, _("Shift-") + _("F5")),
+			("Shift-F6",	"str",	""	, _("Shift-") + _("F6")),
+			("Shift-F7",	"str",	""	, _("Shift-") + _("F7")),
+			("Shift-F8",	"str",	""	, _("Shift-") + _("F8")),
+			("Shift-F9",	"str",	""	, _("Shift-") + _("F9")),
+			("Shift-F10",	"str",	""	, _("Shift-") + _("F10")),
+			("Shift-F11",	"str",	""	, _("Shift-") + _("F11")),
+			("Shift-F12",	"str",	""	, _("Shift-") + _("F12")),
+			("Control-F1",	"str",	""	, _("Control-") + _("F1")),
+			("Control-F2",	"str",	""	, _("Control-") + _("F2")),
+			("Control-F3",	"str",	""	, _("Control-") + _("F3")),
+			("Control-F4",	"str",	""	, _("Control-") + _("F4")),
+			("Control-F5",	"str",	""	, _("Control-") + _("F5")),
+			("Control-F6",	"str",	""	, _("Control-") + _("F6")),
+			("Control-F7",	"str",	""	, _("Control-") + _("F7")),
+			("Control-F8",	"str",	""	, _("Control-") + _("F8")),
+			("Control-F9",	"str",	""	, _("Control-") + _("F9")),
+			("Control-F10",	"str",	""	, _("Control-") + _("F10")),
+			("Control-F11",	"str",	""	, _("Control-") + _("F11")),
+			("Control-F12",	"str",	""	, _("Control-") + _("F12"))
+		]
 		self.buttons.append("exe")
 
 	#----------------------------------------------------------------------


### PR DESCRIPTION
For the translation, String Concatenation is used to reduce the amount of translation.
A newly generated pot.-file will look like this for the translators:

#: ToolsPage.py:481 ToolsPage.py:493 ToolsPage.py:505
msgid "F1"
msgstr ""

#: ToolsPage.py:482 ToolsPage.py:494 ToolsPage.py:506
msgid "F2"
msgstr ""

#: ToolsPage.py:483 ToolsPage.py:495 ToolsPage.py:507
msgid "F3"
msgstr ""

#: ToolsPage.py:484 ToolsPage.py:496 ToolsPage.py:508
msgid "F4"
msgstr ""

#: ToolsPage.py:485 ToolsPage.py:497 ToolsPage.py:509
msgid "F5"
msgstr ""

#: ToolsPage.py:486 ToolsPage.py:498 ToolsPage.py:510
msgid "F6"
msgstr ""

#: ToolsPage.py:487 ToolsPage.py:499 ToolsPage.py:511
msgid "F7"
msgstr ""

#: ToolsPage.py:488 ToolsPage.py:500 ToolsPage.py:512
msgid "F8"
msgstr ""

#: ToolsPage.py:489 ToolsPage.py:501 ToolsPage.py:513
msgid "F9"
msgstr ""

#: ToolsPage.py:490 ToolsPage.py:502 ToolsPage.py:514
msgid "F10"
msgstr ""

#: ToolsPage.py:491 ToolsPage.py:503 ToolsPage.py:515
msgid "F11"
msgstr ""

#: ToolsPage.py:492 ToolsPage.py:504 ToolsPage.py:516
msgid "F12"
msgstr ""

#: ToolsPage.py:493 ToolsPage.py:494 ToolsPage.py:495 ToolsPage.py:496
#: ToolsPage.py:497 ToolsPage.py:498 ToolsPage.py:499 ToolsPage.py:500
#: ToolsPage.py:501 ToolsPage.py:502 ToolsPage.py:503 ToolsPage.py:504
msgid "Shift-"
msgstr ""

#: ToolsPage.py:505 ToolsPage.py:506 ToolsPage.py:507 ToolsPage.py:508
#: ToolsPage.py:509 ToolsPage.py:510 ToolsPage.py:511 ToolsPage.py:512
#: ToolsPage.py:513 ToolsPage.py:514 ToolsPage.py:515 ToolsPage.py:516
msgid "Control-"
msgstr ""