### PR TITLE
changed probing behaviour to avoid exceeding the soft limits during tool change and calibration

### DIFF
--- a/CNC.py
+++ b/CNC.py
@@ -1689,10 +1689,10 @@ class CNC:
 				while currentFeedrate > CNC.vars["prbfeed"]:
 					lines.append("g91 [prbcmd] %s z[-tooldistance]" \
 							% CNC.fmt('f',currentFeedrate))
-					lines.append("[prbcmdreverse] %s z[tooldistance+wz-mz]" \
+					lines.append("[prbcmdreverse] %s z1" \
 							% CNC.fmt('f',currentFeedrate))
 					currentFeedrate /= 10
-			lines.append("g91 [prbcmd] f[prbfeed] z[-tooldistance]")
+			lines.append("g91 [prbcmd] f[prbfeed] z-1")
 
 			if CNC.toolPolicy==2:
 				# Adjust the current WCS to fit to the tool

--- a/ProbePage.py
+++ b/ProbePage.py
@@ -1697,10 +1697,10 @@ class ToolFrame(CNCRibbon.PageFrame):
 			while currentFeedrate > CNC.vars["prbfeed"]:
 				lines.append("g91 [prbcmd] %s z[-tooldistance]" \
 						% CNC.fmt('f',currentFeedrate))
-				lines.append("[prbcmdreverse] %s z[tooldistance+wz-mz]" \
+				lines.append("[prbcmdreverse] %s z1" \
 						% CNC.fmt('f',currentFeedrate))
 				currentFeedrate /= 10
-		lines.append("g91 [prbcmd] f[prbfeed] z[-tooldistance]")
+		lines.append("g91 [prbcmd] f[prbfeed] z-1")
 		lines.append("g4 p1")	# wait a sec
 		lines.append("%wait")
 		lines.append("%global toolheight; toolheight=wz")


### PR DESCRIPTION
During M6 (manual TLO/WCS) commands or calibration the probe is lowered (g38.2) by the tooldistance.
If fastprobefeed is set it is raised with the g38.4 and lowered again (g38.2) by the tooldistance.
As the tool does not move far from the touch plate the second lowering can exceed the soft limits although they are never reached.