### PR TITLE
 update fast probe feed when the field is edited

### DIFF
--- a/CNC.py
+++ b/CNC.py
@@ -1689,10 +1689,10 @@ class CNC:
 				while currentFeedrate > CNC.vars["prbfeed"]:
 					lines.append("g91 [prbcmd] %s z[-tooldistance]" \
 							% CNC.fmt('f',currentFeedrate))
-					lines.append("[prbcmdreverse] %s z[tooldistance+wz-mz]" \
+					lines.append("[prbcmdreverse] %s z1" \
 							% CNC.fmt('f',currentFeedrate))
 					currentFeedrate /= 10
-			lines.append("g91 [prbcmd] f[prbfeed] z[-tooldistance]")
+			lines.append("g91 [prbcmd] f[prbfeed] z-1")
 
 			if CNC.toolPolicy==2:
 				# Adjust the current WCS to fit to the tool

--- a/CNC.py
+++ b/CNC.py
@@ -1689,10 +1689,10 @@ class CNC:
 				while currentFeedrate > CNC.vars["prbfeed"]:
 					lines.append("g91 [prbcmd] %s z[-tooldistance]" \
 							% CNC.fmt('f',currentFeedrate))
-					lines.append("[prbcmdreverse] %s z1" \
+					lines.append("[prbcmdreverse] %s z[tooldistance+wz-mz]" \
 							% CNC.fmt('f',currentFeedrate))
 					currentFeedrate /= 10
-			lines.append("g91 [prbcmd] f[prbfeed] z-1")
+			lines.append("g91 [prbcmd] f[prbfeed] z[-tooldistance]")
 
 			if CNC.toolPolicy==2:
 				# Adjust the current WCS to fit to the tool

--- a/ProbePage.py
+++ b/ProbePage.py
@@ -1697,10 +1697,10 @@ class ToolFrame(CNCRibbon.PageFrame):
 			while currentFeedrate > CNC.vars["prbfeed"]:
 				lines.append("g91 [prbcmd] %s z[-tooldistance]" \
 						% CNC.fmt('f',currentFeedrate))
-				lines.append("[prbcmdreverse] %s z[tooldistance+wz-mz]" \
+				lines.append("[prbcmdreverse] %s z1" \
 						% CNC.fmt('f',currentFeedrate))
 				currentFeedrate /= 10
-		lines.append("g91 [prbcmd] f[prbfeed] z[-tooldistance]")
+		lines.append("g91 [prbcmd] f[prbfeed] z-1")
 		lines.append("g4 p1")	# wait a sec
 		lines.append("%wait")
 		lines.append("%global toolheight; toolheight=wz")

--- a/ProbePage.py
+++ b/ProbePage.py
@@ -1697,10 +1697,10 @@ class ToolFrame(CNCRibbon.PageFrame):
 			while currentFeedrate > CNC.vars["prbfeed"]:
 				lines.append("g91 [prbcmd] %s z[-tooldistance]" \
 						% CNC.fmt('f',currentFeedrate))
-				lines.append("[prbcmdreverse] %s z1" \
+				lines.append("[prbcmdreverse] %s z[tooldistance+wz-mz]" \
 						% CNC.fmt('f',currentFeedrate))
 				currentFeedrate /= 10
-		lines.append("g91 [prbcmd] f[prbfeed] z-1")
+		lines.append("g91 [prbcmd] f[prbfeed] z[-tooldistance]")
 		lines.append("g4 p1")	# wait a sec
 		lines.append("%wait")
 		lines.append("%global toolheight; toolheight=wz")

--- a/ProbePage.py
+++ b/ProbePage.py
@@ -204,7 +204,10 @@ class ProbeCommonFrame(CNCRibbon.PageFrame):
 		# Fast Probe Feed
 		Label(frame, text=_("Fast Probe Feed:")).grid(row=row, column=col, sticky=E)
 		col += 1
-		ProbeCommonFrame.fastProbeFeed = tkExtra.FloatEntry(frame, background="White", width=5)
+		self.fastProbeFeed = StringVar()
+		self.fastProbeFeed.trace("w", lambda *_: ProbeCommonFrame.probeUpdate())
+		ProbeCommonFrame.fastProbeFeed = tkExtra.FloatEntry(frame, background="White", width=5,
+								textvariable=self.fastProbeFeed)
 		ProbeCommonFrame.fastProbeFeed.grid(row=row, column=col, sticky=EW)
 		tkExtra.Balloon.set(ProbeCommonFrame.fastProbeFeed, _("Set initial probe feed rate for tool change and calibration"))
 		self.addWidget(ProbeCommonFrame.fastProbeFeed)


### PR DESCRIPTION
Fast probe feed was only updated when the "regular" probe feed was modified. Now changing the fast probe field also calls the updateProbe()-function.