### PR TITLE
changed probing behaviour to avoid exceeding the soft limits

### DIFF
--- a/ProbePage.py
+++ b/ProbePage.py
@@ -1689,18 +1689,28 @@ class ToolFrame(CNCRibbon.PageFrame):
 		lines.append("g53 g0 x[toolchangex] y[toolchangey]")
 		lines.append("g53 g0 x[toolprobex] y[toolprobey]")
 		lines.append("g53 g0 z[toolprobez]")
-		if CNC.vars["fastprbfeed"]:
+				
+		# probe multiple times with decreasing probe feed
+		if CNC.vars["fastprbfeed"] and CNC.vars["fastprbfeed"] > CNC.vars["prbfeed"]:
 			prb_reverse = {"2": "4", "3": "5", "4": "2", "5": "3"}
-			CNC.vars["prbcmdreverse"] = (CNC.vars["prbcmd"][:-1] +
-						prb_reverse[CNC.vars["prbcmd"][-1]])
+			CNC.vars["prbcmdreverse"] = (CNC.vars["prbcmd"][:-1] + prb_reverse[CNC.vars["prbcmd"][-1]])
 			currentFeedrate = CNC.vars["fastprbfeed"]
-			while currentFeedrate > CNC.vars["prbfeed"]:
-				lines.append("g91 [prbcmd] %s z[-tooldistance]" \
-						% CNC.fmt('f',currentFeedrate))
-				lines.append("[prbcmdreverse] %s z[tooldistance+wz-mz]" \
-						% CNC.fmt('f',currentFeedrate))
-				currentFeedrate /= 10
-		lines.append("g91 [prbcmd] f[prbfeed] z[-tooldistance]")
+			lines.append("g91 [prbcmd] %s z[-tooldistance]" % CNC.fmt('f',currentFeedrate))
+			currentFeedrate /= 10;
+			retract = math.copysign(1, CNC.vars["tooldistance"])
+			while True:
+				if currentFeedrate > CNC.vars["prbfeed"]:
+					lines.append("[prbcmdreverse] %s %s" % (CNC.fmt('f', currentFeedrate), CNC.fmt('z', retract)) )
+					lines.append("[prbcmd] %s %s" % (CNC.fmt('f', currentFeedrate), CNC.fmt('z', -retract)) )
+					currentFeedrate /= 10
+				else:
+					lines.append("[prbcmdreverse] f[prbfeed] %s" % CNC.fmt('z', retract) )
+					lines.append("[prbcmd] f[prbfeed] %s" % CNC.fmt('z', -retract) )
+					break
+		# basic probing
+		else:
+			lines.append("g91 [prbcmd] f[prbfeed] z[-tooldistance]")
+				
 		lines.append("g4 p1")	# wait a sec
 		lines.append("%wait")
 		lines.append("%global toolheight; toolheight=wz")


### PR DESCRIPTION
Changed probing behaviour to avoid exceeding the soft limits during tool change and calibration.
Problem:
During M6 (manual TLO/WCS) commands or the probe is lowered (g38.2) by the tooldistance. If fastprobefeed is set it is raised with the g38.4 and lowered again (g38.2) by the tooldistance. As the tool does not move far from the touch plate the second lowering can exceed the soft limits althoug they are never reached.
Solution:
Probe only 1mm after the probe lost contact.
Optional other solution:
Do not reverse probe but only retract for example 1mm and then probe 1.5mm or so.