### PR TITLE
added "%wait" commands to obtain the correct mz during probing

### DIFF
--- a/CNC.py
+++ b/CNC.py
@@ -1687,11 +1687,14 @@ class CNC:
 							     prb_reverse[CNC.vars["prbcmd"][-1]])
 				currentFeedrate = CNC.vars["fastprbfeed"]
 				while currentFeedrate > CNC.vars["prbfeed"]:
+					lines.append("%wait")
 					lines.append("g91 [prbcmd] %s z[toolprobez-mz-tooldistance]" \
 							% CNC.fmt('f',currentFeedrate))
+					lines.append("%wait")
 					lines.append("[prbcmdreverse] %s z[toolprobez-mz]" \
 							% CNC.fmt('f',currentFeedrate))
 					currentFeedrate /= 10
+			lines.append("%wait")
 			lines.append("g91 [prbcmd] f[prbfeed] z[toolprobez-mz-tooldistance]")
 
 			if CNC.toolPolicy==2:

--- a/ProbePage.py
+++ b/ProbePage.py
@@ -1700,11 +1700,14 @@ class ToolFrame(CNCRibbon.PageFrame):
 						prb_reverse[CNC.vars["prbcmd"][-1]])
 			currentFeedrate = CNC.vars["fastprbfeed"]
 			while currentFeedrate > CNC.vars["prbfeed"]:
+				lines.append("%wait")
 				lines.append("g91 [prbcmd] %s z[toolprobez-mz-tooldistance]" \
 						% CNC.fmt('f',currentFeedrate))
+				lines.append("%wait")
 				lines.append("[prbcmdreverse] %s z[toolprobez-mz]" \
 						% CNC.fmt('f',currentFeedrate))
 				currentFeedrate /= 10
+		lines.append("%wait")
 		lines.append("g91 [prbcmd] f[prbfeed] z[toolprobez-mz-tooldistance]")
 		lines.append("g4 p1")	# wait a sec
 		lines.append("%wait")


### PR DESCRIPTION
I made wrong assumption about the "mz". I thought it is evaluated after the previous command but in fact it is evaluated as soon as it is fed into the command queue and thus, leading to wrong calculations.
The "%wait" now ensures that the movement has finished before evaluating mz.
Now all my probing scenarios work correctly.