### PR TITLE
Translatable labelframe + added missing translating fields

### DIFF
--- a/CNCRibbon.py
+++ b/CNCRibbon.py
@@ -79,8 +79,8 @@ class PageFrame(Frame, _LinkApp):
 # Page, LabelFrame
 #===============================================================================
 class PageLabelFrame(LabelFrame, _LinkApp):
-	def __init__(self, master, name, app):
-		LabelFrame.__init__(self, master, text=name, foreground="DarkBlue")
+	def __init__(self, master, name, name_alias_lng, app):
+		LabelFrame.__init__(self, master, text=name_alias_lng, foreground="DarkBlue")
 		_LinkApp.__init__(self, app)
 		self.name = name
 
@@ -88,8 +88,8 @@ class PageLabelFrame(LabelFrame, _LinkApp):
 # Page, ExLabelFrame
 #===============================================================================
 class PageExLabelFrame(tkExtra.ExLabelFrame, _LinkApp):
-	def __init__(self, master, name, app):
-		tkExtra.ExLabelFrame.__init__(self, master, text=name, foreground="DarkBlue")
+	def __init__(self, master, name, name_alias_lng, app):
+		tkExtra.ExLabelFrame.__init__(self, master, text=name_alias_lng, foreground="DarkBlue")
 		_LinkApp.__init__(self, app)
 		self.name = name
 

--- a/ControlPage.py
+++ b/ControlPage.py
@@ -426,7 +426,7 @@ class DROFrame(CNCRibbon.PageFrame):
 #===============================================================================
 class ControlFrame(CNCRibbon.PageLabelFrame):
 	def __init__(self, master, app):
-		CNCRibbon.PageLabelFrame.__init__(self, master, "Control", app)
+		CNCRibbon.PageLabelFrame.__init__(self, master, "Control", _("Control"), app)
 
 		row,col = 0,0
 		Label(self, text=_("Z")).grid(row=row, column=col)
@@ -803,7 +803,7 @@ class ControlFrame(CNCRibbon.PageLabelFrame):
 class StateFrame(CNCRibbon.PageExLabelFrame):
 	def __init__(self, master, app):
 		global wcsvar
-		CNCRibbon.PageExLabelFrame.__init__(self, master, "State", app)
+		CNCRibbon.PageExLabelFrame.__init__(self, master, "State", _("State"), app)
 		self._gUpdate = False
 
 		# State

--- a/FilePage.py
+++ b/FilePage.py
@@ -216,8 +216,7 @@ class CloseGroup(CNCRibbon.ButtonGroup):
 #===============================================================================
 class SerialFrame(CNCRibbon.PageLabelFrame):
 	def __init__(self, master, app):
-		CNCRibbon.PageLabelFrame.__init__(self, master, "Serial", app)
-
+		CNCRibbon.PageLabelFrame.__init__(self, master, "Serial", _("Serial"), app)
 		self.autostart = BooleanVar()
 
 		# ---

--- a/ProbePage.py
+++ b/ProbePage.py
@@ -490,7 +490,7 @@ class ProbeFrame(CNCRibbon.PageFrame):
 		row += 1
 		col = 0
 
-		Label(lframe(), text="WPos:").grid(row=row, column=col, sticky=E)
+		Label(lframe(), text=_("WPos:")).grid(row=row, column=col, sticky=E)
 		col += 1
 		self.xm_orient = tkExtra.FloatEntry(lframe(), background="White")
 		self.xm_orient.grid(row=row, column=col, sticky=EW)
@@ -827,12 +827,12 @@ class AutolevelFrame(CNCRibbon.PageFrame):
 		col += 1
 		Label(lframe, text=_("Step")).grid(row=row, column=col, sticky=EW)
 		col += 1
-		Label(lframe, text="N").grid(row=row, column=col, sticky=EW)
+		Label(lframe, text=_("N")).grid(row=row, column=col, sticky=EW)
 
 		# --- X ---
 		row += 1
 		col = 0
-		Label(lframe, text="X:").grid(row=row, column=col, sticky=E)
+		Label(lframe, text=_("X:")).grid(row=row, column=col, sticky=E)
 		col += 1
 		self.probeXmin = tkExtra.FloatEntry(lframe, background="White", width=5)
 		self.probeXmin.grid(row=row, column=col, sticky=EW)
@@ -864,7 +864,7 @@ class AutolevelFrame(CNCRibbon.PageFrame):
 		# --- Y ---
 		row += 1
 		col  = 0
-		Label(lframe, text="Y:").grid(row=row, column=col, sticky=E)
+		Label(lframe, text=_("Y:")).grid(row=row, column=col, sticky=E)
 		col += 1
 		self.probeYmin = tkExtra.FloatEntry(lframe, background="White", width=5)
 		self.probeYmin.grid(row=row, column=col, sticky=EW)
@@ -897,7 +897,7 @@ class AutolevelFrame(CNCRibbon.PageFrame):
 		row += 1
 		col  = 0
 
-		Label(lframe, text="Z:").grid(row=row, column=col, sticky=E)
+		Label(lframe, text=_("Z:")).grid(row=row, column=col, sticky=E)
 		col += 1
 		self.probeZmin = tkExtra.FloatEntry(lframe, background="White", width=5)
 		self.probeZmin.grid(row=row, column=col, sticky=EW)
@@ -1475,11 +1475,11 @@ class ToolFrame(CNCRibbon.PageFrame):
 		# ----
 		row += 1
 		col  = 1
-		Label(lframe, text="MX").grid(row=row, column=col, sticky=EW)
+		Label(lframe, text=_("MX")).grid(row=row, column=col, sticky=EW)
 		col += 1
-		Label(lframe, text="MY").grid(row=row, column=col, sticky=EW)
+		Label(lframe, text=_("MY")).grid(row=row, column=col, sticky=EW)
 		col += 1
-		Label(lframe, text="MZ").grid(row=row, column=col, sticky=EW)
+		Label(lframe, text=_("MZ")).grid(row=row, column=col, sticky=EW)
 
 		# --- Tool Change position ---
 		row += 1


### PR DESCRIPTION
- CNCRibbon.py: class PageLabelFrame
- CNCRibbon.py: class PageExLabelFrame
- Filepage.py: class SerialFrame
- ControlPage.py: class ControlFrame
- ControlPage.py: class StateFrame

Tested with a newly generated local pot file on my machine and it works fine