### PR TITLE
[WIP] Supported KiCad Excellon DRL format

### DIFF
--- a/plugins/driller.py
+++ b/plugins/driller.py
@@ -49,11 +49,11 @@ class Tool(Plugin):
 
 	# Excellon Coordsconvert
 	def coord2float(self, text, unitinch):
-		if '.' in text: return float(text)*0.1
+		if '.' in text: return float(text)
 		if unitinch==True: return float(text)*0.0001
 		#unit mm
-		if len(text)==5: return int(text)*0.01
-		if len(text)==6: return int(text)*0.001
+		if len(text)==(6 if text[0]=='-' else 5): return int(text)*0.01
+		if len(text)==(7 if text[0]=='-' else 6): return int(text)*0.001
 
 	#convert to systemsetting
 	def convunit(self, value, unitinch):
@@ -77,7 +77,7 @@ class Tool(Plugin):
 					#read header
 					if line=="M48": header = True
 					if header==True:
-						if (line=="INCH" or line=="METRIC"): unitinch = line=="INCH"
+						if (line.startswith("INCH") or line.startswith("METRIC")): unitinch = line.startswith("INCH")
 						if (line=="M95" or line=="%"): header = False
 						if line[0]=="T":
 							#tools

--- a/plugins/driller.py
+++ b/plugins/driller.py
@@ -49,7 +49,8 @@ class Tool(Plugin):
 
 	# Excellon Coordsconvert
 	def coord2float(self, text, unitinch):
-		if unitinch==True: return int(text)*0.0001
+		if '.' in text: return float(text)*0.1
+		if unitinch==True: return float(text)*0.0001
 		#unit mm
 		if len(text)==5: return int(text)*0.01
 		if len(text)==6: return int(text)*0.001
@@ -86,7 +87,7 @@ class Tool(Plugin):
 					if header==False:
 						if line[0]=="T": current_tool = line
 						if line[0]=="X":
-							m = re.match('X(\d+)Y(\d+)',line)
+							m = re.match(r'X([\d\.-]+)Y([\d\.-]+)',line)
 							# convert to system
 							x = self.convunit( self.coord2float(m.group(1), unitinch), unitinch)
 							y = self.convunit( self.coord2float(m.group(2), unitinch), unitinch)


### PR DESCRIPTION
If you export from KiCad like this (Decimal format)
![image](https://user-images.githubusercontent.com/7802808/42621161-bd0111e6-85c5-11e8-9716-b6b811549a10.png)
The codes will be like this 
```
X-44.Y-71.
X-44.Y-93.5
X-38.7Y-13.725
```
We spent much time to figure out what's wrong with all tools from Google and why did not they eat this correctly. Reading this plugin's source code made me realize how bad are things with the Excellon parsers