### PR TITLE
Recover from stuck sio_wait in Alarm and Error states

### DIFF
--- a/bCNC/controllers/GRBL0.py
+++ b/bCNC/controllers/GRBL0.py
@@ -38,7 +38,7 @@ class Controller(_GenericGRBL):
 			# stop waiting and go on
 			#print "<<< WAIT=",wait,sline,pat.group(1),sum(cline)
 			#print ">>>", line
-			if self.master.sio_wait and not cline and pat.group(1) in ("Idle","Check", "Alarm", "error"):
+			if self.master.sio_wait and not cline and pat.group(1) not in ("Run", "Jog", "Hold"):
 				#print ">>>",line
 				self.master.sio_wait = False
 				#print "<<< NO MORE WAIT"

--- a/bCNC/controllers/GRBL0.py
+++ b/bCNC/controllers/GRBL0.py
@@ -38,7 +38,7 @@ class Controller(_GenericGRBL):
 			# stop waiting and go on
 			#print "<<< WAIT=",wait,sline,pat.group(1),sum(cline)
 			#print ">>>", line
-			if self.master.sio_wait and not cline and pat.group(1) in ("Idle","Check"):
+			if self.master.sio_wait and not cline and pat.group(1) in ("Idle","Check", "Alarm", "error"):
 				#print ">>>",line
 				self.master.sio_wait = False
 				#print "<<< NO MORE WAIT"

--- a/bCNC/controllers/GRBL1.py
+++ b/bCNC/controllers/GRBL1.py
@@ -174,7 +174,7 @@ class Controller(_GenericGRBL):
 
 
 		# Machine is Idle buffer is empty stop waiting and go on
-		if self.master.sio_wait and not cline and fields[0] in ("Idle","Check", "Alarm", "error"):
+		if self.master.sio_wait and not cline and fields[0] not in ("Run", "Jog", "Hold"):
 			#if not self.master.running: self.master.jobDone() #This is not a good idea, it purges the controller while waiting for toolchange. see #1061
 			self.master.sio_wait = False
 			self.master._gcount += 1

--- a/bCNC/controllers/GRBL1.py
+++ b/bCNC/controllers/GRBL1.py
@@ -174,7 +174,7 @@ class Controller(_GenericGRBL):
 
 
 		# Machine is Idle buffer is empty stop waiting and go on
-		if self.master.sio_wait and not cline and fields[0] in ("Idle","Check"):
+		if self.master.sio_wait and not cline and fields[0] in ("Idle","Check", "Alarm", "error"):
 			#if not self.master.running: self.master.jobDone() #This is not a good idea, it purges the controller while waiting for toolchange. see #1061
 			self.master.sio_wait = False
 			self.master._gcount += 1

--- a/bCNC/controllers/SMOOTHIE.py
+++ b/bCNC/controllers/SMOOTHIE.py
@@ -69,7 +69,7 @@ class Controller(_GenericController):
 
 		# Machine is Idle buffer is empty
 		# stop waiting and go on
-		if self.master.sio_wait and not cline and l[0] in ("Idle","Check", "Alarm", "error"):
+		if self.master.sio_wait and not cline and l[0] not in ("Run","Jog", "Hold"):
 		        self.master.sio_wait = False
 		        self.master._gcount += 1
 

--- a/bCNC/controllers/SMOOTHIE.py
+++ b/bCNC/controllers/SMOOTHIE.py
@@ -69,7 +69,7 @@ class Controller(_GenericController):
 
 		# Machine is Idle buffer is empty
 		# stop waiting and go on
-		if self.master.sio_wait and not cline and l[0] in ("Idle","Check"):
+		if self.master.sio_wait and not cline and l[0] in ("Idle","Check", "Alarm", "error"):
 		        self.master.sio_wait = False
 		        self.master._gcount += 1
 


### PR DESCRIPTION
Hi!
This is a simple fix that solves sender freezes in situations when G38.2 or similar commands followed by %wait result in grbl Alarm state. In such cases bCNC keeps sio_wait==True until hard reset clears that flag. Soft reset does not help if grbl is configured to use homing cycle because it remains in Alarm state after soft reset and sio_wait remains true.

This definitely works with GRBL1 but I am not so sure about GRBL0 or smoothie.