### PR TITLE
Try to restore TLO value on controller unlock and reset

### DIFF
--- a/bCNC/ProbePage.py
+++ b/bCNC/ProbePage.py
@@ -338,7 +338,8 @@ class ProbeCommonFrame(CNCRibbon.PageFrame):
 	def loadConfig(self):
 		ProbeCommonFrame.fastProbeFeed.set(Utils.getFloat("Probe","fastfeed"))
 		ProbeCommonFrame.probeFeed.set(Utils.getFloat("Probe","feed"))
-		ProbeCommonFrame.tlo.set(      Utils.getFloat("Probe","tlo"))
+		CNC.vars["TLO"] = Utils.getFloat("Probe","tlo")
+		ProbeCommonFrame.tlo.set(CNC.vars["TLO"])
 		cmd = Utils.getStr("Probe","cmd")
 		for p in PROBE_CMD:
 			if p.split()[0] == cmd:

--- a/bCNC/Sender.py
+++ b/bCNC/Sender.py
@@ -117,6 +117,7 @@ class Sender:
 		self._stop	 = False	# Raise to stop current run
 		self._pause	 = False	# machine is on Hold
 		self._alarm	 = True		# Display alarm message if true
+		self._controllerReset = False # Controller reset was just detected and some G-code vars should be restored (e.g. TLO)
 		self._msg	 = None
 		self._sumcline	 = 0
 		self._lastFeed	 = 0
@@ -772,6 +773,10 @@ class Sender:
 				# so don't stop
 				if self._runLines != sys.maxsize:
 					self._stop = False
+					if self._controllerReset:
+						TLO = CNC.vars["TLO"]
+						self.sendGCode("G43.1Z%s"%(TLO))	# restore TLO
+						self._controllerReset = False
 
 			#print "tosend='%s'"%(repr(tosend)),"stack=",sline,
 			#	"sum=",sum(cline),"wait=",wait,"pause=",self._pause

--- a/bCNC/controllers/_GenericController.py
+++ b/bCNC/controllers/_GenericController.py
@@ -230,6 +230,7 @@ class _GenericController:
 			#tg = time.time()
 			self.master.log.put((self.master.MSG_RECEIVE, line))
 			self.master._stop = True
+			self.master._controllerReset = True
 			del cline[:]	# After reset clear the buffer counters
 			del sline[:]
 			CNC.vars["version"] = line.split()[1]


### PR DESCRIPTION
Hi!
Here are some efforts to make "Manual tool change (TLO)" policy more usable. Grbl zeroes TLO on every reset and unlock event. And bCNC keep showing stored TLO value until manual $# is issued and real value gets parsed or until tool change cycle is executed.
This behavior require manual sending of tool change commands after every controller unlock or reset. Forgetting to run a tool change cycle leads to either a soft-limit error (best case but still annoying) or a tool crush.
I am not sure if these changes cover every possible TLO reset scenario. And the code is really ugly, especially use of purgeControllerExtra. But it makes my work with bCNC much easier. Not sure how to code it in a better way.