### PR TITLE
Fix crash on hw "Run" button press with no gcode in editor

### DIFF
--- a/bCNC/__main__.py
+++ b/bCNC/__main__.py
@@ -2254,6 +2254,7 @@ class Application(Toplevel,Sender):
 				self.purgeController()
 				return
 			elif not self._paths:
+				self.runEnded()
 				tkMessageBox.showerror(_("Empty gcode"),
 					_("Not gcode file was loaded"),
 					parent=self)

--- a/bCNC/controllers/GRBL1.py
+++ b/bCNC/controllers/GRBL1.py
@@ -166,7 +166,7 @@ class Controller(_GenericGRBL):
 					if 'S' in word[1]:
 						if CNC.vars["state"] == 'Idle' and not self.master.running:
 							print("Stream requested by CYCLE START machine button")
-							self.master.event_generate("<<Run>>")
+							self.master.event_generate("<<Run>>", when = 'tail')
 						else:
 							print("Ignoring machine stream request, because of state: ", CNC.vars["state"], self.master.running)
 				except (ValueError,IndexError):


### PR DESCRIPTION
It's a small patch that fixes a couple of issues with pressing HW "Start" button with no g-code lines present in editor.
First - it prevents a crash in `event_generate -> tkMessageBox.showError` call chain from the Sender thread. As stated here: https://bytes.com/topic/python/answers/512683-problems-tkinter-threads and (not so clearly) in docs: https://www.tcl.tk/man/tcl/TkCmd/event.htm#M7 events are dispatched immediately and on the calling thread when invoked without 'when' parameter. Adding `when = 'tail'` moves event processing to the main thread and `showError` no longer crashes the app.
Second - it removes "Running" state that is set a few lines before the "editor empty" check is made.