### PR TITLE
Move initial focus from file name to file list in open/save dialog

### DIFF
--- a/bCNC/lib/bFileDialog.py
+++ b/bCNC/lib/bFileDialog.py
@@ -371,7 +371,7 @@ class FileDialog(Toplevel):
 		try:
 			self.lift()
 			self.focus_set()
-			self.filename.focus_set()
+			self.fileList.focus_set()
 			self.wait_visibility()
 			self.grab_set()
 			self.wait_window()


### PR DESCRIPTION
Opening a file using only a keyboard is a bit cumbersome because you need to shift-tab to a file list to navigate through files and folders.
Setting initial focus to file name may be useful in save dialog (but still questionable IMO) but is absolutely useless in open dialog. Will you ever type a filename that you want to open (without autocomplete) instead of just selecting it with arrow keys?