### PR TITLE
Fix for issue #1169

### DIFF
--- a/bCNC/CNC.py
+++ b/bCNC/CNC.py
@@ -298,12 +298,12 @@ class Probe:
 		self.makeMatrix()
 		x = self.xmin
 		xstep = self._xstep
-		lines = ["G0Z%.4f"%(CNC.vars["safe"]),
+		lines = ["G0Z%.4fF%g"%(CNC.vars["safe"],CNC.vars["fastprbfeed"]),
 			 "G0X%.4fY%.4f"%(self.xmin, self.ymin)]
 		for j in range(self.yn):
 			y = self.ymin + self._ystep*j
 			for i in range(self.xn):
-				lines.append("G0Z%.4f"%(self.zmax))
+				lines.append("G0Z%.4fF%g"%(self.zmax,CNC.vars["fastprbfeed"]))
 				lines.append("G0X%.4fY%.4f"%(x,y))
 				lines.append("%wait")	# added for smoothie
 				lines.append("%sZ%.4fF%g"%(CNC.vars["prbcmd"], self.zmin, CNC.vars["prbfeed"]))
@@ -311,7 +311,7 @@ class Probe:
 				x += xstep
 			x -= xstep
 			xstep = -xstep
-		lines.append("G0Z%.4f"%(self.zmax))
+		lines.append("G0Z%.4fF%g"%(self.zmax,CNC.vars["fastprbfeed"]))
 		lines.append("G0X%.4fY%.4f"%(self.xmin,self.ymin))
 		return lines
 


### PR DESCRIPTION
While autolevel scanning, all the moves except probing now use the Fast Probe Feed speed setting. This speeds up autolevel scanning considerably. #1169 
Edit: Tested with Smoothieboard with latest CNC firmware (GRBL mode is default here). In my case, a 2 hour scan now takes 30 minutes.