### PR TITLE
Add content length on pendant request + Override Data

### DIFF
--- a/bCNC/Pendant.py
+++ b/bCNC/Pendant.py
@@ -133,11 +133,11 @@ class Pendant(HTTPServer.BaseHTTPRequestHandler):
 						Image.open(tmp.name).save(out.name, 'GIF')
 						out.flush()
 						out.seek(0)
-						self.do_HEAD(200, content="image/gif")
+						self.do_HEAD(200, content="image/gif", cl=os.path.getsize(tmp.name))
 						self.wfile.write(out.read())
 				except:
-					self.do_HEAD(200, content="image/gif")
 					filename = os.path.join(iconpath, "warn.gif")
+					self.do_HEAD(200, content="image/gif", cl=os.path.getsize(filename))
 					try:
 						f = open(filename,"rb")
 						self.wfile.write(f.read())
@@ -154,7 +154,7 @@ class Pendant(HTTPServer.BaseHTTPRequestHandler):
 			if Pendant.camera.read():
 				Pendant.camera.save("camera.jpg")
 				#cv.imwrite("camera.jpg",img)
-				self.do_HEAD(200, content="image/jpeg")
+				self.do_HEAD(200, content="image/jpeg", cl=os.path.getsize("camera.jpg"))
 				try:
 					f = open("camera.jpg","rb")
 					self.wfile.write(f.read())

--- a/bCNC/Pendant.py
+++ b/bCNC/Pendant.py
@@ -32,7 +32,7 @@ except ImportError:
 	Image = None
 
 try:
-		import BaseHTTPServer as HTTPServer
+	import BaseHTTPServer as HTTPServer
 except ImportError:
 	import http.server as HTTPServer
 
@@ -100,7 +100,7 @@ class Pendant(HTTPServer.BaseHTTPRequestHandler):
 				tmp[name] = CNC.vars[name]
 			contentToSend = json.dumps(tmp)
 			self.do_HEAD(200, content="text/text", cl=len(contentToSend))
-			self.wfile.write(json.dumps(tmp))
+			self.wfile.write(contentToSend)
 
 		elif page == "/config":
 			snd = {}


### PR DESCRIPTION
This PR is to update de pendant request to add content-size in header to optimize http request and add override data.

This will be helpfull in IOT (arduino / stm32 / etc) project to reduce to get the data : when there is no size content, the iot frameworks wait 1s before get the data.

I update Pendant tools to build a bCNC panel (hardware).