### PR TITLE
Scripting now always has access to app

### DIFF
--- a/bCNC/CNC.py
+++ b/bCNC/CNC.py
@@ -1091,8 +1091,9 @@ class CNC:
 			else:
 				try:
 					return compile(line[1:],"","exec")
-				except:
-					# FIXME show the error!!!!
+				except Exception as e:
+					print("Compile line error: \n")
+					print(e)
 					return None
 
 		# most probably an assignment like  #nnn = expr

--- a/bCNC/CNCCanvas.py
+++ b/bCNC/CNCCanvas.py
@@ -1814,7 +1814,7 @@ class CNCCanvas(Canvas, object):
 							before = time.time()
 						n = 1000
 					try:
-						cmd = self.gcode.evaluate(CNC.compileLine(line))
+						cmd = self.gcode.evaluate(CNC.compileLine(line), self.app)
 						if isinstance(cmd,tuple):
 							cmd = None
 						else:

--- a/bCNC/Sender.py
+++ b/bCNC/Sender.py
@@ -707,7 +707,7 @@ class Sender:
 
 					elif not isinstance(tosend,str):
 						try:
-							tosend = self.gcode.evaluate(tosend)
+							tosend = self.gcode.evaluate(tosend, self)
 #							if isinstance(tosend, list):
 #								cline.append(len(tosend[0]))
 #								sline.append(tosend[0])


### PR DESCRIPTION
Fixes #1375
This change:
Improved scriptability #1256
https://github.com/vlachoudis/bCNC/commit/4456ad2abe63121899e4833f0b3b04323d6e278c

Added the ability for scripting to access 'app', however it only added this for the commandline.
The pull request adds the functionality in two other places.

- sender.py:200           - commandline
- CNCCanvas.py:1817 - opening gcode and rendering
- sener.py:710             - running