### PR TITLE
Reduce halftone plugin output steps with conical mill 

### DIFF
--- a/bCNC/plugins/halftone.py
+++ b/bCNC/plugins/halftone.py
@@ -226,11 +226,12 @@ class Tool(Plugin):
 			blockCon = Block("%s-Conical"%(self.name))
 			for c in circles:
 				x,y,r = c
-				blockCon.append(CNC.zsafe())
-				blockCon.append(CNC.grapid(x,y))
-				dv = r / math.tan(math.radians(v_angle/2.))
-				blockCon.append(CNC.zenter(-dv))
-			blockCon.append(CNC.zsafe())
+				if (r >= dMin/2.):
+					blockCon.append(CNC.zsafe())
+					blockCon.append(CNC.grapid(x,y))
+					dv = r / math.tan(math.radians(v_angle/2.))
+					blockCon.append(CNC.zenter(-dv))
+					blockCon.append(CNC.zsafe())
 			blocks.append(blockCon)
 
 		#Gcode Zsafe

--- a/bCNC/plugins/halftone.py
+++ b/bCNC/plugins/halftone.py
@@ -231,7 +231,7 @@ class Tool(Plugin):
 					blockCon.append(CNC.grapid(x,y))
 					dv = r / math.tan(math.radians(v_angle/2.))
 					blockCon.append(CNC.zenter(-dv))
-					blockCon.append(CNC.zsafe())
+			blockCon.append(CNC.zsafe())
 			blocks.append(blockCon)
 
 		#Gcode Zsafe


### PR DESCRIPTION
Patch to halftone plugin adds conditional to skip motion commands for spots below min size when the conical mill option is selected. Behaviour mirrors the main "circle" code conditional and results in significant reduction in output for sparse images. 