### PR TITLE
Fix opencv-python version, last version with python 2.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
 		"pyserial<=3.0.1 ; sys_platform == 'win32'",
 		'numpy>=1.12',
 		'Pillow>=4.0',
-		'opencv-python>=2.4 ; ("arm" not in platform_machine) and ("aarch64" not in platform_machine)',	#Note there are no PyPI OpenCV packages for ARM (Raspberry PI, Orange PI, etc...)
+		'opencv-python==4.2.0.32 ; ("arm" not in platform_machine) and ("aarch64" not in platform_machine)',	#Note there are no PyPI OpenCV packages for ARM (Raspberry PI, Orange PI, etc...)
 	],
 
 	entry_points = {


### PR DESCRIPTION
Following https://stackoverflow.com/questions/63346648/python-2-7-installing-opencv-via-pip-virtual-environment.

@Harvie python 2.7 is end-of-life. Libraries start dropping support.