### PR TITLE
Fix opencv-python version, with conditional formatting to point python 2.7 to the last supported version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,6 @@ if sys.version_info[0] >= 3:
 else: #python version lower then 3 compatability
 	opencv_version ='4.2.0.32' # use the last opencv version for python 2.7
 
-print("opencv_version = ",opencv_version)
-print("S= %s" % (opencv_version))
-
 setup(
 	name = "bCNC",
 	version = "0.9.14.308",

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,17 @@
 from setuptools import setup, find_packages
-
+import sys #added for python2 support
 print("Running bCNC setup...")
 
 with open("README.md", "r") as fh:
 	long_description = fh.read()
+
+if sys.version_info[0] >= 3:
+	opencv_version = '4.4.0.46' # Recent version for Puthon 3
+else: #python version lower then 3 compatability
+	opencv_version ='4.2.0.32' # use the last opencv version for python 2.7
+
+print("opencv_version = ",opencv_version)
+print("S= %s" % (opencv_version))
 
 setup(
 	name = "bCNC",
@@ -27,7 +35,7 @@ setup(
 		"pyserial<=3.0.1 ; sys_platform == 'win32'",
 		'numpy>=1.12',
 		'Pillow>=4.0',
-		'opencv-python==4.2.0.32 ; ("arm" not in platform_machine) and ("aarch64" not in platform_machine)',	#Note there are no PyPI OpenCV packages for ARM (Raspberry PI, Orange PI, etc...)
+		'opencv-python==%s ; ("arm" not in platform_machine) and ("aarch64" not in platform_machine)' % (opencv_version),	#Note there are no PyPI OpenCV packages for ARM (Raspberry PI, Orange PI, etc...)
 	],
 
 	entry_points = {


### PR DESCRIPTION
Supporting both python 2.7 and version 3 is hard when the opencv module dropped python 2 support.

Commits like:
https://github.com/lgv2018/bCNC/commit/fef44488ffb7dae469f5891a1b22f002d010a40b trying to fix #1468 
fixed python 2 support, but broke python 3 support as mentioned in #1417 .

Some (LTS) distro's still defaults to python 2. @Harvie wanted to keep support for python 2.

To keep supporting both python versions conditional formatting is needed.
Python 2.7 will be pointed to the last supported openCV version. (4.2.0.32)
Python 3 will be pointed to install the recent opencv version.


Implements some of the code as discussed in  pull request https://github.com/vlachoudis/bCNC/pull/1454
thanks to @GitHubCaps 


