### PR TITLE
Fix bug in dragknife plugin

### DIFF
--- a/bCNC/plugins/dragknife.py
+++ b/bCNC/plugins/dragknife.py
@@ -109,7 +109,7 @@ This fact introduces the need for preprocessing the g-code to account with that 
 					else:
 						arcdir = Segment.CCW
 
-					#Append swivel if needed (also always do entry/exit)
+					#Append swivel if needed (with an angle threshold of 1 degree on entry/exit segments)
 					if abs(angle) > angleth or (abs(angle) > 1 and ( i == 0 or i == len(opath)-1 )):
 						arca = Segment(arcdir, prevseg.tangentialOffset(dragoff).B, seg.tangentialOffset(dragoff).A, prevseg.B)
 
@@ -118,7 +118,16 @@ This fact introduces the need for preprocessing the g-code to account with that 
 
 					#Append segment with tangential offset
 					if i < len(opath)-1:
-						npath.append(seg.tangentialOffset(dragoff))
+						newSeg = seg.tangentialOffset(dragoff)
+						# To keep the path connected, we use the end of the
+						# previous segment as the start of this segment.
+						# if there is no previous entry, use the ventry vector
+						if len(npath) == 0:
+							newSeg.setStart(ventry.B)
+						else:
+							newSeg.setStart(npath[-1].B)
+
+						npath.append(newSeg)
 
 					prevseg = seg
 


### PR DESCRIPTION
The dragknife plugin currently produces arcs that fail validation when
sent to grbl.

When the tangentialOffset method is called on an arc segment, both it's
start and end position are offset. The center is moved such that it is
equidistant between these new positions. This produces a valid arc.
However, when turned into GCode, only the center and end positions are
used - the start position is assumed to be the end position of the
previous command. This _isn't_ a valid arc, and GCode processors like
grbl will report errors when sent this GCode.

This commit fixes the problem by using the end of the previous (tangentially
offset) segment as the start of subsequent offset arc segments.