### PR TITLE
bCNC.desktop: add Keyword key

### DIFF
--- a/bCNC/bCNC.desktop
+++ b/bCNC/bCNC.desktop
@@ -5,6 +5,7 @@ Name=bCNC
 Comment=bCNC Controller
 Exec=bCNC
 Icon=bCNC.png
+Keywords=CNC;PCB;
 Path=
 Terminal=true
 StartupNotify=false


### PR DESCRIPTION
The `Keywords` entry is recommended to be present in `*.desktop` files. We can add a few keywords as a first start.