### PR TITLE
remove unused shebangs

### DIFF
--- a/bCNC/Sender.py
+++ b/bCNC/Sender.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: ascii -*-
 # $Id: bCNC.py,v 1.6 2014/10/15 15:04:48 bnv Exp bnv $
 #

--- a/bCNC/lib/bFileDialog.py
+++ b/bCNC/lib/bFileDialog.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: ascii -*-
 #
 # Copyright and User License

--- a/bCNC/lib/dxf.py
+++ b/bCNC/lib/dxf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: ascii -*-
 #
 # Copyright and User License

--- a/bCNC/lib/imageToGcode.py
+++ b/bCNC/lib/imageToGcode.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 ## image-to-gcode is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by the
 ## Free Software Foundation; either version 2 of the License, or (at your

--- a/bCNC/lib/spline.py
+++ b/bCNC/lib/spline.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: latin1 -*-
 #
 # Author: vvlachoudis@gmail.com


### PR DESCRIPTION
Some shebangs are used in files which are not executable. Thus they are not useful and should be removed.