### PR TITLE
Fix mouse wheel zooming in both directions on Mac

### DIFF
--- a/bCNC/CNCCanvas.py
+++ b/bCNC/CNCCanvas.py
@@ -1008,7 +1008,9 @@ class CNCCanvas(Canvas, object):
 
 	# ----------------------------------------------------------------------
 	def wheel(self, event):
-		self.zoomCanvas(event.x, event.y, pow(ZOOM,(event.delta//120)))
+		scaledDelta = event.delta / 120
+		deltaPower = math.ceil(scaledDelta) if scaledDelta > 0 else math.floor(scaledDelta)
+		self.zoomCanvas(event.x, event.y, pow(ZOOM, deltaPower))
 
 	# ----------------------------------------------------------------------
 	# Change the insert marker location


### PR DESCRIPTION
This PR fixes https://github.com/vlachoudis/bCNC/issues/804

Here is original zoom wheel handler code:
```python
def wheel(self, event):
    self.zoomCanvas(event.x, event.y, pow(ZOOM,(event.delta//120)))
```

`event.delta` equals -1 (scroll up) or 1 (scroll down) on my setup (MacOS 12.2.1, Logitech MX 3 mouse, medium scrolling speed in system settings, "natural" scroll direction). In Python 2 rounding goes away from zero, so `event.delta//120` gives either 1 or -1, which is OK. But running in Python 3.9, `event.delta//120` results -1 or 0. That why only one zooming direction works.

I propose a fix that seems compatible both with Python 2 and 3 and should not break or change scrolling behavior.