### PR TITLE
Fix various typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ There are too much commits, so i've created this brief overview of new features 
   - Added button to activate GRBL sleep mode (= disable motors) #1099
   - Added button to trigger GRBL door alarm
   - Added button to scan autoleveling margins (to see what will be probed)
-  - Added some usefull jog buttons
+  - Added some useful jog buttons
   - Added framework to show help text and images for each plugin #806
 - Bug Fixes
   - Proper path direction detection and climb/conventional support #881

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Before making pull request, please test your code on both python2 and python3.
 
 # Installation (using pip = recommended!)
 
-This is short overview of installation proces, for more see the ![bCNC installation](https://github.com/vlachoudis/bCNC/wiki/Installation) wiki page.
+This is a short overview of the installation process, for more details see the ![bCNC installation](https://github.com/vlachoudis/bCNC/wiki/Installation) wiki page.
 
 This is how you install (or upgrade) bCNC along with all required packages.
 You can use any of these commands (you need only one):
@@ -88,8 +88,8 @@ please check first if that bug occurs even when running directly in python (with
 
 # IMPORTANT! Motion controller (grblHAL) settings
 - We strongly recommend you to use 32b microcontroller with grblHAL firmware for the new machine builds. https://github.com/grblHAL (Original GRBL firmware is still supported, but it is currently reaching the end-of-life due to limitations of 8b microcontrollers)
-- GRBL should be configured to use **MPos** rather than **Wpos**. This means that `$10=` should be set to odd number. As of GRBL 1.1 we reccomend setting `$10=3`. If you have troubles communicating with your machine, you can try to set failsafe value `$10=1`.
-- CADs, bCNC and GRBL all work in milimeters by default. Make sure that `$13=0` is set in GRBL, if you experience strange behavior. (unless you've configured your CAD and bCNC to use inches)
+- GRBL should be configured to use **MPos** rather than **Wpos**. This means that `$10=` should be set to odd number. As of GRBL 1.1 we recommend setting `$10=3`. If you have troubles communicating with your machine, you can try to set failsafe value `$10=1`.
+- CADs, bCNC and GRBL all work in millimeters by default. Make sure that `$13=0` is set in GRBL, if you experience strange behavior. (unless you've configured your CAD and bCNC to use inches)
 - Before filing bug please make sure you use latest stable official release of GRBL. Older and unofficial releases might work, but we frequently see cases where they don't. So please upgrade firmware in your Arduinos to reasonably recent version if you can.
 - Also read about all possible GRBL settings and make sure your setup is correct: https://github.com/gnea/grbl/wiki/Grbl-v1.1-Configuration
 - GrblHAL also has "Compatibility level" settings which have to be correctly configured during firmware compilation: https://github.com/grblHAL/core/wiki/Compatibility-level

--- a/bCNC/CNC.py
+++ b/bCNC/CNC.py
@@ -1028,7 +1028,7 @@ class CNC:
         )
 
     # ----------------------------------------------------------------------
-    # Number formating
+    # Number formatting
     # ----------------------------------------------------------------------
     @staticmethod
     def fmt(c, v, d=None):
@@ -1252,7 +1252,7 @@ class CNC:
             return None
 
         out = []  # output list of commands
-        braket = 0  # bracket count []
+        bracket = 0  # bracket count []
         paren = 0  # parenthesis count ()
         expr = ""  # expression string
         cmd = ""  # cmd string
@@ -1261,7 +1261,7 @@ class CNC:
             if ch == "(":
                 # comment start?
                 paren += 1
-                inComment = braket == 0
+                inComment = bracket == 0
                 if not inComment:
                     expr += ch
             elif ch == ")":
@@ -1276,8 +1276,8 @@ class CNC:
                 if not inComment:
                     if CNC.stdexpr:
                         ch = "("
-                    braket += 1
-                    if braket == 1:
+                    bracket += 1
+                    if bracket == 1:
                         if cmd:
                             out.append(cmd)
                             cmd = ""
@@ -1290,8 +1290,8 @@ class CNC:
                 if not inComment:
                     if CNC.stdexpr:
                         ch = ")"
-                    braket -= 1
-                    if braket == 0:
+                    bracket -= 1
+                    if bracket == 0:
                         try:
                             out.append(compile(expr, "", "eval"))
                         except Exception:
@@ -1304,7 +1304,7 @@ class CNC:
                     CNC.comment += ch
             elif ch == "=":
                 # check for assignments (FIXME very bad)
-                if not out and braket == 0 and paren == 0:
+                if not out and bracket == 0 and paren == 0:
                     for i in " ()-+*/^$":
                         if i in cmd:
                             cmd += ch
@@ -1317,13 +1317,13 @@ class CNC:
                             return None
             elif ch == ";":
                 # Skip everything after the semicolon on normal lines
-                if not inComment and paren == 0 and braket == 0:
+                if not inComment and paren == 0 and bracket == 0:
                     CNC.comment += line[i + 1:]
                     break
                 else:
                     expr += ch
 
-            elif braket > 0:
+            elif bracket > 0:
                 expr += ch
 
             elif not inComment:
@@ -3722,7 +3722,7 @@ class GCode:
                     drillHole(lines)
 
             elif distance is None and number == 0:
-                # Drill on path begining only
+                # Drill on path beginning only
                 for i, line in enumerate(block):
                     cmds = CNC.parseLine(line)
                     if cmds is None:
@@ -4174,7 +4174,7 @@ class GCode:
                 # tablock.color = "#FF0000"
                 tablock.color = "orange"
                 tablock.enable = (
-                    False  # Prevent tabs from being accidentaly cut as path
+                    False  # Prevent tabs from being accidentally cut as path
                 )
 
                 # Add regular tabs
@@ -4260,7 +4260,7 @@ class GCode:
             side = self.blocks[bid].operationSide()
             if abs(direction) > 1 and side == 0:
                 msg = "Conventional/Climb feature only works for paths with 'in/out/pocket' tags!\n"
-                msg += "Some of the selected paths were not taged (or are both in+out). You can still use CW/CCW for them."
+                msg += "Some of the selected paths were not tagged (or are both in+out). You can still use CW/CCW for them."
                 continue
             if direction == 2:
                 operation = "conventional,"

--- a/bCNC/ControlPage.py
+++ b/bCNC/ControlPage.py
@@ -1675,7 +1675,7 @@ class abcControlFrame(CNCRibbon.PageExLabelFrame):
     def moveBdownCup(self, event=None):
         if event is not None and not self.acceptKey():
             return
-        # XXX: Posible error in original code lead to %C string; fixed by guessing from methods below.
+        # XXX: Possible error in original code lead to %C string; fixed by guessing from methods below.
         # Original: self.app.mcontrol.jog("B-%C%s"%(self.step.get(),self.step.get()))
         self.app.mcontrol.jog(f"B-{self.step.get()}C{self.step.get()}")
 

--- a/bCNC/Sender.py
+++ b/bCNC/Sender.py
@@ -183,7 +183,7 @@ class Sender:
 
     # ----------------------------------------------------------------------
     # Evaluate a line for possible expressions
-    # can return a python exception, needs to be catched
+    # can return a python exception, needs to be caught
     # ----------------------------------------------------------------------
     def evaluate(self, line):
         return self.gcode.evaluate(CNC.compileLine(line, True), self)
@@ -787,7 +787,7 @@ class Sender:
                     if pat is not None:
                         self._lastFeed = pat.group(2)
 
-                    # Modify sent g-code to reflect overrided feed for
+                    # Modify sent g-code to reflect overridden feed for
                     # controllers without override support
                     if not self.mcontrol.has_override:
                         if CNC.vars["_OvChanged"]:

--- a/bCNC/ToolsPage.py
+++ b/bCNC/ToolsPage.py
@@ -800,7 +800,7 @@ class Cut(DataBase):
                 "exitpoint",
                 "on path,inside,outside",
                 "on path",
-                _("Exit strategy (usefull for threads)"),
+                _("Exit strategy (useful for threads)"),
                 _(
                     "You should probably always use 'on path', unless "
                     + "you are threadmilling!"
@@ -820,7 +820,7 @@ class Cut(DataBase):
                 _("Compensate islands for cutter radius"),
                 _(
                     "Add additional margin/offset around islands to "
-                    + "compensate for endmill radius. This is automaticaly "
+                    + "compensate for endmill radius. This is automatically "
                     + "done for all islands if they are marked as tabs."
                 ),
             ),
@@ -843,7 +843,7 @@ class Cut(DataBase):
             + "\"cut contours of islands\"",
             "If you want islands to get finishing pass, cou can use "
             + "\"cut contours of selected islands\" or cut them "
-            + "individualy afterwards.",
+            + "individually afterwards.",
         ])
 
     # ----------------------------------------------------------------------
@@ -959,7 +959,7 @@ class Drill(DataBase):
             "* dwell: Dwell time at the bottom. If pecking is defined, dwell "
             + "also at lifted height.",
             "",
-            "* distance: Distance between drills if drilling alog path. "
+            "* distance: Distance between drills if drilling along path. "
             + "(Number of drills will superceed this parameter))",
             "",
             "* number: Number of drills if drilling along path. If nonzero, "

--- a/bCNC/bmain.py
+++ b/bCNC/bmain.py
@@ -570,7 +570,7 @@ class Application(Tk, Sender):
         self.setStatus(_(event.data))
 
     # -----------------------------------------------------------------------
-    # Show popup dialog asking for value entry, usefull in g-code scripts
+    # Show popup dialog asking for value entry, useful in g-code scripts
     # -----------------------------------------------------------------------
     def entry(
         self,
@@ -1606,7 +1606,7 @@ class Application(Tk, Sender):
             except Exception:
                 self.importFile()
 
-        # INK*SCAPE: remove uneccessary Z motion as a result of inkscape
+        # INK*SCAPE: remove unnecessary Z motion as a result of inkscape
         # gcodetools
         elif rexx.abbrev("INKSCAPE", cmd, 3):
             if len(line) > 1 and rexx.abbrev("ALL", line[1].upper()):

--- a/bCNC/controllers/_GenericController.py
+++ b/bCNC/controllers/_GenericController.py
@@ -218,7 +218,7 @@ class _GenericController:
         # Do not show g-code errors, when machine is already in alarm state
         if (CNC.vars["state"].startswith("ALARM:")
                 and state.startswith("error:")):
-            print(f"Supressed: {state}")
+            print(f"Suppressed: {state}")
             return
 
         # Do not show alarm without number when we already
@@ -287,5 +287,5 @@ class _GenericController:
             # Sender will log the line in such case
             return False
 
-        # Parsing succesfull
+        # Parsing successful
         return True

--- a/bCNC/controllers/_GenericGRBL.py
+++ b/bCNC/controllers/_GenericGRBL.py
@@ -19,7 +19,7 @@ ERROR_CODES = {
     ),
     "Jog": _("Grbl executes jogging motion"),
     "Sleep": _(
-        "Grbl is in sleep mode. Motors are disabled, so you can move them manualy. That also means that your machine might have lost the position (or microsteps) and you may need to re-zero. Perform reset+unlock (or stop) to wake Grbl again."
+        "Grbl is in sleep mode. Motors are disabled, so you can move them manually. That also means that your machine might have lost the position (or microsteps) and you may need to re-zero. Perform reset+unlock (or stop) to wake Grbl again."
     ),
     "Queue": _(
         "Grbl is in queue state. This also means you have relatively old GRBL version, there are even 0.9 versions newer than this."
@@ -122,7 +122,7 @@ ERROR_CODES = {
     "error:62": _("SD Card directory listing failed. (grblHAL bdring)"),
     "error:63": _("SD Card directory not found. (grblHAL bdring)"),
     "error:64": _("SD Card file empty. (grblHAL bdring)"),
-    "error:70": _("Bluetooth initalisation failed. (grblHAL bdring)"),
+    "error:70": _("Bluetooth initialisation failed. (grblHAL bdring)"),
     "ALARM:1": _(
         "Hard limit triggered. Machine position is likely lost due to sudden and immediate halt. Re-homing is highly recommended."
     ),

--- a/bCNC/lib/bmath.py
+++ b/bCNC/lib/bmath.py
@@ -950,7 +950,7 @@ class Matrix(list):
     # ----------------------------------------------------------------------
     @staticmethod
     def rotY(angle):
-        """m = Matrix.rotY(angle) - Return a rotation matrix arround Y"""
+        """m = Matrix.rotY(angle) - Return a rotation matrix around Y"""
         m = Matrix(4, type_=1)
         m.rotate(angle, 1)
         return m
@@ -958,7 +958,7 @@ class Matrix(list):
     # ----------------------------------------------------------------------
     @staticmethod
     def rotZ(angle):
-        """m = Matrix.rotZ(angle) - Return a rotation matrix arround Z"""
+        """m = Matrix.rotZ(angle) - Return a rotation matrix around Z"""
         m = Matrix(4, type_=1)
         m.rotate(angle, 2)
         return m

--- a/bCNC/lib/bpath.py
+++ b/bCNC/lib/bpath.py
@@ -298,7 +298,7 @@ class Segment:
         return self.extrapolatePoint(self.length() / 2)
 
     # ----------------------------------------------------------------------
-    # Return segment, which naturaly continues this segment
+    # Return segment, which naturally continues this segment
     # ----------------------------------------------------------------------
     def suffixSegment(self, dist):
         suffix = Segment(self.type, self.B, self.extrapolatePoint(dist, True))
@@ -307,7 +307,7 @@ class Segment:
         return suffix
 
     # ----------------------------------------------------------------------
-    # Return segment, which naturaly continues this segment
+    # Return segment, which naturally continues this segment
     # ----------------------------------------------------------------------
     def shortenedSegment(self, dist):
         start = self.extrapolatePoint(dist)
@@ -838,7 +838,7 @@ class Path(list):
         # This is kinda heuristic. If we ever need better results, there's way to do it:
         # Just split all arcs into 10 smaller arcs before processing.
         # That will vastly increase the resolution of linear approximation.
-        # If you know to split arcs, plese do it. For now we have this heuristic:
+        # If you know to split arcs, please do it. For now we have this heuristic:
 
         if sum_ == 0:
             if cwarc < 0:
@@ -952,7 +952,7 @@ class Path(list):
 
             # Check if there are no parts of arc going far away from the
             # original lines
-            # FIXME: currently only comparing lenghts and middle points
+            # FIXME: currently only comparing lengths and middle points
             if len(path) > 1:
                 path._length = None
                 arc = Segment(arcd2seg(arcd), path[0].A, path[-1].B, C)
@@ -1358,7 +1358,7 @@ class Path(list):
             oi = self[i].order(P)
             points.append((i, oi, P))
 
-        # Find all interesection points
+        # Find all intersection points
         for i, si in enumerate(self[:-2]):
             if si.type == Segment.LINE and self[i + 1].type == Segment.LINE:
                 j = i + 2
@@ -1377,7 +1377,7 @@ class Path(list):
                     addPoint(j, P2)
                 j += 1
 
-        # sort accoring to index, and position of point
+        # sort according to index, and position of point
         points.sort(key=itemgetter(0, 1))
 
         # split paths
@@ -1411,7 +1411,7 @@ class Path(list):
             oi = self[i].order(P)
             points.append((i, oi, P))
 
-        # Find all interesection points
+        # Find all intersection points
         for i, si in enumerate(self):
             for cut in path:
                 P1, P2 = si.intersect(cut)
@@ -1423,7 +1423,7 @@ class Path(list):
                 if P2:
                     addPoint(i, P2)
 
-        # sort accoring to index, and position of point
+        # sort according to index, and position of point
         points.sort(key=itemgetter(0, 1))
 
         # split paths
@@ -1436,7 +1436,7 @@ class Path(list):
         # Mark inside segments
         # FIXME: for some reason this fails if doing multiple intersections
         #        in such case you have to intersect all paths and then mark
-        #        them using markInside() additionaly
+        #        them using markInside() additionally
         if setinside is not None:
             self.markInside(path, setinside)
 
@@ -1637,7 +1637,7 @@ class Path(list):
 
     # ----------------------------------------------------------------------
     # @return True if distance of P to the current path is < EPS,
-    # refering to minimum distance from P to every Segment of path
+    # referring to minimum distance from P to every Segment of path
     # ----------------------------------------------------------------------
     def isOnPath(self, P):
         mindist = float("inf")
@@ -1660,10 +1660,10 @@ class Path(list):
     # the intersections added must be different from previous found
     # if there is no intersection (nbInter == 0) ,
     #     the the segment is inside if one of its points is inside,
-    #     else it is outisde
+    #     else it is outside
     # if there is one single intersection(nbInter == 1),
     #     segment is inside if it has one point inisde
-    # if there are 2 ore more interesections (nbInter >=2),
+    # if there are 2 or more intersections (nbInter >=2),
     #     this is a little ambiguous, since the segment could make a
     #     chord on an arc, or could be a chord of a seg
     # in this case, we ignore chords, and consider that if 2 points of

--- a/bCNC/lib/bstl.py
+++ b/bCNC/lib/bstl.py
@@ -38,7 +38,7 @@ def normalto(u, v):
 def crossProduct(a, b):
     # calculate cross product of two threedimensional vectors
     if (len(a) != 3) or (len(b) != 3):
-        raise ValueError("unvalid value")
+        raise ValueError("invalid value")
     return [
         a[1] * b[2] - a[2] * b[1],
         a[2] * b[0] - a[0] * b[2],
@@ -47,9 +47,9 @@ def crossProduct(a, b):
 
 
 def diff(v1, v2):
-    # substracting one list from another
+    # subtracting one list from another
     if (len(v1) != 3) or (len(v2) != 3):
-        raise ValueError("unvalid value")
+        raise ValueError("invalid value")
     return [v1[0] - v2[0], v1[1] - v2[1], v1[2] - v2[2]]
 
 
@@ -57,7 +57,7 @@ def normal(v1, v2, v3):
     # calculate normal vector on triangle spanned by the three vertices
     # tells in which direction the plane looks "right-thumb-rule"
     if (len(v1) != 3) or (len(v2) != 3) or (len(v2) != 3):
-        raise ValueError("unvalid value")
+        raise ValueError("invalid value")
     n = crossProduct(diff(v2, v1), diff(v3, v1))
     absolut = 0
     for i in n:

--- a/bCNC/lib/python_utils/converters.py
+++ b/bCNC/lib/python_utils/converters.py
@@ -7,7 +7,7 @@ def to_int(input_, default=0, exception=(ValueError, TypeError), regexp=None):
     Convert the given input to an integer or return default
 
     When trying to convert the exceptions given in the exception parameter
-    are automatically catched and the default will be returned.
+    are automatically caught and the default will be returned.
 
     The regexp parameter allows for a regular expression to find the digits
     in a string.
@@ -88,7 +88,7 @@ def to_float(input_,
     Convert the given `input_` to an integer or return default
 
     When trying to convert the exceptions given in the exception parameter
-    are automatically catched and the default will be returned.
+    are automatically caught and the default will be returned.
 
     The regexp parameter allows for a regular expression to find the digits
     in a string.

--- a/bCNC/lib/python_utils/logger.py
+++ b/bCNC/lib/python_utils/logger.py
@@ -6,7 +6,7 @@ __all__ = ["Logged"]
 
 class Logged:
     """Class which automatically adds a named logger to your class when
-    interiting
+    inheriting
 
     Adds easy access to debug, info, warning, error, exception and log methods
 

--- a/bCNC/lib/spline.py
+++ b/bCNC/lib/spline.py
@@ -229,7 +229,7 @@ def spline2Polyline(xyz, degree, closed, segments, knots):
 # equal to the order at the ends.
 #    c            = order of the basis function
 #    n            = the number of defining polygon vertices
-#    n+2          = index of x[] for the first occurence of the maximum knot
+#    n+2          = index of x[] for the first occurrence of the maximum knot
 #                   vector value
 #    n+order      = maximum value of the knot vector -- $n + c$
 #    x[]          = array containing the knot vector

--- a/bCNC/lib/spline.py
+++ b/bCNC/lib/spline.py
@@ -74,7 +74,7 @@ class CardinalSpline:
 # Cubic spline ensuring that the first and second derivative are continuous
 # adapted from Penelope Manual Appending B.1
 # It requires all the points (xi,yi) and the assumption on how to deal
-# with the second derviative on the extremeties
+# with the second derivative on the extremeties
 # Option 1: assume zero as second derivative on both ends
 # Option 2: assume the same as the next or previous one
 # =============================================================================

--- a/bCNC/lib/tkExtra.py
+++ b/bCNC/lib/tkExtra.py
@@ -205,7 +205,7 @@ ADs=
 #     widget.event_generate("<<VirtualEvent>>", data=("One","Two"))
 #     widget.event_generate("<<VirtualEvent>>", serial=10, data=("One","Two"))
 #
-# WARNING: Unfortunatelly it will convert data to STRING!!!
+# WARNING: Unfortunately it will convert data to STRING!!!
 # -----------------------------------------------------------------------------
 def bindEventData(widget, sequence, func, add=None):
     def _substitute(*args):
@@ -824,7 +824,7 @@ class ExListbox(Listbox):
         self.usermenu = None  # Assign a user-popup menu
         # Should be a list with tuples
         #  in the form:
-        #  (label, underline, commmand)
+        #  (label, underline, command)
         # or None for separator
 
     # ----------------------------------------------------------------------
@@ -3518,7 +3518,7 @@ class Splitter(Frame):
     # Set the split position
     # ----------------------------------------------------------------------
     def setSplit(self, newSplit):
-        """Change the spliting position"""
+        """Change the splitting position"""
         self._setSplit(newSplit)
         self.placeChilds()
 

--- a/bCNC/lib/ttf.py
+++ b/bCNC/lib/ttf.py
@@ -515,7 +515,7 @@ class TruetypeInfo:
             ce, g_offset = self._get_data(">H", g_offset)  # uint16
             glyph.contoursEnd.append(ce)
 
-        # skip over intructions
+        # skip over instructions
         seek, g_offset = self._get_data(">H", g_offset)  # uint16
         g_offset += seek
 

--- a/bCNC/lib/ttf.py
+++ b/bCNC/lib/ttf.py
@@ -42,7 +42,7 @@
 # ----------------------------------------------------------------------------
 
 #
-# Deriver from Alex Holkner work for pyglet
+# Derived from Alex Holkner work for pyglet
 # Glyph data ported from
 # * http://stevehanov.ca/blog/index.php?id=143
 # the JavaScript code to extract also Glyph data as vector.

--- a/bCNC/pendant/fastclick.js
+++ b/bCNC/pendant/fastclick.js
@@ -430,7 +430,7 @@
         // when the user next taps anywhere else on the page, new touchstart and touchend events are dispatched
         // with the same identifier as the touch event that previously triggered the click that triggered the alert.
         // Sadly, there is an issue on iOS 4 that causes some normal touch events to have the same identifier as an
-        // immediately preceeding touch event (issue #52), so this fix is unavailable on that platform.
+        // immediately preceding touch event (issue #52), so this fix is unavailable on that platform.
         // Issue 120: touch.identifier is 0 when Chrome dev tools 'Emulate touch events' is set with an iOS device UA string,
         // which causes all touch events to be ignored. As this block only applies to iOS, and iOS identifiers are always long,
         // random integers, it's safe to to continue if the identifier is 0 here.
@@ -842,7 +842,7 @@
       }
     }
 
-    // IE11: prefixed -ms-touch-action is no longer supported and it's recomended to use non-prefixed version
+    // IE11: prefixed -ms-touch-action is no longer supported and it's recommended to use non-prefixed version
     // http://msdn.microsoft.com/en-us/library/windows/apps/Hh767313.aspx
     if (
       layer.style.touchAction === "none" ||

--- a/bCNC/plugins/Helical_Descent.py
+++ b/bCNC/plugins/Helical_Descent.py
@@ -92,7 +92,7 @@ class Tool(Plugin):
                 _("Helical Type"),
             ),
             ("Entry", "Center,Edge", "Center", _("Entry and Exit")),
-            ("ClearanceEntry", "mm", 0.0, _("If Eddge, Edge Clearance")),
+            ("ClearanceEntry", "mm", 0.0, _("If Edge, Edge Clearance")),
             ("NoReturnToSafeZ", "bool", "False", _("End in the Deep")),
         ]
 
@@ -265,7 +265,7 @@ class Tool(Plugin):
 
         elif entry == "":
             app.setStatus(
-                _("Helical Abort: Please selecte Entry and Exit type"))
+                _("Helical Abort: Please select Entry and Exit type"))
             return
 
         elif clearanceEntry < 0 or clearanceEntry == "":

--- a/bCNC/plugins/arcfit.py
+++ b/bCNC/plugins/arcfit.py
@@ -53,12 +53,12 @@ class Tool(Plugin):
         )  # <<< This is the button added at bottom to call the execute method below
         self.help = """
 This plugin will try to simplify the g-code by replacing amounts of short subsequent lines by one long arc.
-There are some precision tunables which will allow you to define how much the resulting arc can differ from orignal lines.
+There are some precision tunables which will allow you to define how much the resulting arc can differ from original lines.
 This plugin can reverse the output of "linearize" plugin, which does the opposite.
 This is not really meant to fillet sharp corners. But rather to reduce the number of g-code lines while preserving the toolpath shape.
 This can be also useful for postprocessing of imported DXF/SVG splines. Splines have to be subdivided to short lines when importing and this can simplify the resulting code.
 Another usecase is to postprocess mesh slices as STL/PLY format is based on triangles, it will never perfectly describe circles and arcs. You can use this plugin to simplify/smooth shapes imported from 3D mesh files.
-Before this plugin tries to fit arcs it also tries to fit and merge longest possible lines within given precision. Line precision should be set much lower than arc precision, otherwise the line merging algorithm will "eat" lines that belong to arcs. Unless you want to do massive shape simplification and don't mind loosing details.
+Before this plugin tries to fit arcs it also tries to fit and merge longest possible lines within given precision. Line precision should be set much lower than arc precision, otherwise the line merging algorithm will "eat" lines that belong to arcs. Unless you want to do massive shape simplification and don't mind losing details.
 """
 
     # ----------------------------------------------------------------------

--- a/bCNC/plugins/dragknife.py
+++ b/bCNC/plugins/dragknife.py
@@ -67,7 +67,7 @@ class Tool(Plugin):
                 "X+",
                 _("initial direction"),
                 _(
-                    "direction that knife blade is facing before and after cut. Eg.: if you set this to X+, then the knifes rotation axis should be on the right side of the tip. Meaning that the knife is ready to cut towards right immediately without pivoting. If you cut multiple shapes in single operation, it's important to have this set consistently across all of them."
+                    "direction that knife blade is facing before and after cut. Eg.: if you set this to X+, then the knife's rotation axis should be on the right side of the tip. Meaning that the knife is ready to cut towards right immediately without pivoting. If you cut multiple shapes in single operation, it's important to have this set consistently across all of them."
                 ),
             ),
             ("feed", "mm", 200, _("feedrate")),
@@ -77,7 +77,7 @@ class Tool(Plugin):
                 False,
                 _("simulate"),
                 _(
-                    "Use this option to simulate cuting of dragknife path. Resulting shape will reflect what shape will actuall be cut. This should reverse the dragknife procedure and give you back the original shape from g-code that was previously processed for dragknife."
+                    "Use this option to simulate cuting of dragknife path. Resulting shape will reflect what shape will actually be cut. This should reverse the dragknife procedure and give you back the original shape from g-code that was previously processed for dragknife."
                 ),
             ),
             (

--- a/bCNC/plugins/driller.py
+++ b/bCNC/plugins/driller.py
@@ -162,7 +162,7 @@ class Tool(Plugin):
         blocks = []
         for tool in data["tools"]:
             dia = self.convunit(data["tools"][tool]["diameter"], unitinch)
-            # Duplicates shouldn't be in the list - remove unnessesary
+            # Duplicates shouldn't be in the list - remove unnecessary
             blockholes = [data["tools"][tool]["holes"]]
             block, holesCount = self.create_block(
                 blockholes, n + " (" + str(dia) + " " + unittext + ")"

--- a/bCNC/plugins/drillmark.py
+++ b/bCNC/plugins/drillmark.py
@@ -28,7 +28,7 @@ class Tool(Plugin):
         self.icon = "crosshair"
         self.group = "Generator"
 
-        # a variable that will be converted in mm/inch based on bCNC settting
+        # a variable that will be converted in mm/inch based on bCNC setting
         self.variables = [
             (
                 "name",

--- a/bCNC/plugins/function_plot.py
+++ b/bCNC/plugins/function_plot.py
@@ -8,7 +8,7 @@ __name__ = _("Function")
 __version__ = "2.5.1"
 
 
-# I'm not commenting theese lines, I just copied them from https://github.com/vlachoudis/bCNC/wiki/Tutorials:-How-to-create-a-plugin
+# I'm not commenting these lines, I just copied them from https://github.com/vlachoudis/bCNC/wiki/Tutorials:-How-to-create-a-plugin
 class Tool(Plugin):
     __doc__ = _("""Generates gcode from a formula""")
 
@@ -37,7 +37,7 @@ class Tool(Plugin):
 
         self.help = """
 This plugin plots graph of a function.
-There are some examples of function formulas that can be ploted:
+There are some examples of function formulas that can be plotted:
 
 - x**2
 - sin(x)
@@ -90,12 +90,12 @@ TODO
         X = []
         Y = []
 
-        e_old = ""  # Store old exception to comapre
+        e_old = ""  # Store old exception to compare
 
         # Calculate values for arguments with a resolution
         for i in range(
             0, int(ran[0] / res + 1)
-        ):  # Complaints about values beeing floats
+        ):  # Complaints about values being floats
             x = i * res + minX  # Iterate x
             X.append(x)
             try:
@@ -244,7 +244,7 @@ TODO
                 x = mapc(X[i] + cent[0], 0)  # Take an argument
                 y = mapc(Y[i] + cent[1], 1)  # Take a value
             else:
-                y = Y[i]  # only for tne None checks next
+                y = Y[i]  # only for the None checks next
 
             # If a None "period" just started raise Z
             if y is None and not raised:

--- a/bCNC/plugins/halftone.py
+++ b/bCNC/plugins/halftone.py
@@ -1,7 +1,7 @@
 # $Id$
 #
 # Author:    Filippo Rivato
-# Date: 14 Febbruary 2016
+# Date: 14 February 2016
 
 import math
 

--- a/bCNC/plugins/linearize.py
+++ b/bCNC/plugins/linearize.py
@@ -54,8 +54,8 @@ class Tool(Plugin):
         )  # <<< This is the button added at bottom to call the execute method below
         self.help = """
 This plugin will subdivide the toolpath in such way, that all segments are broken to very short lines, which means that there will be no arcs or splines.
-This is exact opposite of "arcfit" plugin. This is not very usefull for common CNC operation. However this might be useful when you need to proces arcs in CAD/CAM software which only support straight lines.
-It usualy happens that new development features and plugins in bCNC only support straight lines and they add support for arcs later. So if you are early adopter of development features or encounter arc-related bug, you might try to use this plugin to convert your g-code to lines before working using these new features.
+This is exact opposite of "arcfit" plugin. This is not very useful for common CNC operation. However this might be useful when you need to process arcs in CAD/CAM software which only support straight lines.
+It usually happens that new development features and plugins in bCNC only support straight lines and they add support for arcs later. So if you are early adopter of development features or encounter arc-related bug, you might try to use this plugin to convert your g-code to lines before working using these new features.
 Also if you are working with some primitive motion controller, which only supports straight lines (G1). You might use this plugin to preprocess the g-code to get support for arcs (G2 and G3).
 
 If you set the segment size large enough, you can even use this to create inscribed polygons in arcs and circles.

--- a/bCNC/plugins/linearize.py
+++ b/bCNC/plugins/linearize.py
@@ -36,7 +36,7 @@ class Tool(Plugin):
                 "1",
                 _("segment size"),
                 _(
-                    "Maximal length of resulting lines, smaller number means more precise output and longer g-code. Length will be automaticaly truncated to be even across whole subdivided segment."
+                    "Maximal length of resulting lines, smaller number means more precise output and longer g-code. Length will be automatically truncated to be even across whole subdivided segment."
                 ),
             ),
             (

--- a/bCNC/plugins/scaling.py
+++ b/bCNC/plugins/scaling.py
@@ -98,7 +98,7 @@ class Tool(Plugin):
                     xyz = app.cnc.motionPath()
                     app.cnc.motionEnd()
                     if xyz:
-                        # coment its?
+                        # comment its?
                         # -----------------------------------------------------
                         # exclude if fast move or z only movement
                         Zonly = (xyz[0][0] == xyz[1][0]

--- a/bCNC/plugins/sketch.py
+++ b/bCNC/plugins/sketch.py
@@ -274,7 +274,7 @@ class Tool(Plugin):
         else:
             img = img.convert("L")  # to calculate luminance
 
-        img = img.transpose(Image.FLIP_TOP_BOTTOM)  # ouput correct image
+        img = img.transpose(Image.FLIP_TOP_BOTTOM)  # output correct image
         pix = img.load()
         # Get image size
         self.imgWidth, self.imgHeight = img.size

--- a/bCNC/plugins/slicemesh.py
+++ b/bCNC/plugins/slicemesh.py
@@ -93,7 +93,7 @@ STL (Binary and ASCII)
 PLY (ASCII only)
 
 You can use external software to edit and convert meshes to desired format.
-It can also help you to visualy inspect your meshes before slicing.
+It can also help you to visually inspect your meshes before slicing.
 Example of useful free software for working with meshes is called "MeshLab".
 
 WARNING:

--- a/bCNC/plugins/spiral.py
+++ b/bCNC/plugins/spiral.py
@@ -91,7 +91,7 @@ class Spiral:
             if dr is True or dr == "yes":
                 app.setStatus(
                     _("Risk Accepted")
-                )  # Using positive logic, if python returns ANYTHING other than True/yes this will not make g-code.  Incase Python uses No instead of False
+                )  # Using positive logic, if python returns ANYTHING other than True/yes this will not make g-code.  In case Python uses No instead of False
             else:
                 return
         if StockLeng <= 0:

--- a/bCNC/plugins/text.py
+++ b/bCNC/plugins/text.py
@@ -128,7 +128,7 @@ class Tool(Plugin):
                 else:
                     xOffset += 1
 
-        # Remeber to close Font
+        # Remember to close Font
         font.close()
 
         # Gcode Zsafe

--- a/bCNC/plugins/trochoidPath.py
+++ b/bCNC/plugins/trochoidPath.py
@@ -7,7 +7,7 @@
 # A special thanks to Filippo Rivato and Vasilis.
 # This plugin is based on a variation
 # of yours plugin Driller and My_Plugin example.
-# To correct: Thats why the first point starts,
+# To correct: That's why the first point starts,
 
 
 from CNC import CNC  # , Block  # << without this error it does not find CNC.vars
@@ -22,10 +22,10 @@ __version__ = "1.0"
 
 
 # =============================================================================
-# Create Trochoidadl rute along selected blocks
+# Create Trochoidadl route along selected blocks
 # =============================================================================
 class Tool(Plugin):
-    __doc__ = _("Create a trochoid rute along selected blocks")
+	__doc__ = _("Create a trochoid route along selected blocks")
 
     def __init__(self, master):
         Plugin.__init__(self, master, "Trochoid_Path")  # NAME OF THE PLUGIN

--- a/bCNC/plugins/trochoidal.py
+++ b/bCNC/plugins/trochoidal.py
@@ -117,7 +117,7 @@ class Tool(Plugin):
                     blocks.append(eblock)
                     entry = False
 
-                # Continuity BEGINING
+                # Continuity BEGINNING
                 # calculate number of subsegments to be transformed to
                 # trochoidal motion
                 srdoc = rdoc

--- a/bCNC/plugins/trochoidal_3D.py
+++ b/bCNC/plugins/trochoidal_3D.py
@@ -555,7 +555,7 @@ class Tool(Plugin):
                                     )
                             adaptativepolice = 0
 
-                        # /////// Adapative method //////////////////////////
+                        # /////// Adaptive method //////////////////////////
                         else:
                             if adaptativepolice == 1:
                                 # goes to de two warning movements
@@ -775,7 +775,7 @@ class Tool(Plugin):
                         tr_block.extend(
                             self.helical(B, B, helicalRadius, phi, u))
                         if round(helicalRadius, 4) != round(radius, 4):
-                            tr_block.append("(Spiral adjustement)")
+                            tr_block.append("(Spiral adjustment)")
                             tr_block.append(
                                 "(Spiral " + str(spiral_twists) + " twists)"
                             )
@@ -1186,7 +1186,7 @@ class Tool(Plugin):
                     alpha1 -= 2 * pi
         if steps == 0:
             steps = 2
-        # delta or increas in values radius, anle, center position
+        # delta or increase in values radius, anle, center position
         d_r = r2 - r1
         d_r = d_r / steps
 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot  -L absolut,actualy,ans,ba,childs,currenty,dum,enew,ro,ser,yse`