### PR TITLE
Use Subprocess instead of os

### DIFF
--- a/bCNC/bmain.py
+++ b/bCNC/bmain.py
@@ -5,6 +5,7 @@
 # Date: 24-Aug-2014
 
 import os
+import subprocess
 import socket
 import sys
 import time
@@ -2572,7 +2573,7 @@ class Application(Tk, Sender):
         CNC.vars["_OvChanged"] = True  # force a feed change if any
         if self._onStart:
             try:
-                os.system(self._onStart)
+                subprocess.call(self._onStart, shell=False)
             except Exception:
                 pass
 


### PR DESCRIPTION
An quick attempt to silence B605: start_process_with_a_shell.

```
This rule looks for the spawning of a subprocess using a command shell. This type of subprocess invocation is dangerous as it is vulnerable to various shell injection attacks. Great care should be taken to sanitize all input in order to mitigate this risk. Calls of this type are identified by the use of certain commands which are known to use shells.
```