### PR TITLE
[FIX] reset buffer bar text formatting

### DIFF
--- a/bCNC/bmain.py
+++ b/bCNC/bmain.py
@@ -2808,7 +2808,7 @@ class Application(Tk, Sender):
             )
             CNC.vars["msg"] = self.statusbar.msg
             self.bufferbar.setProgress(Sender.getBufferFill(self))
-            self.bufferbar.setText(f"{Sender.getBufferFill(self)}%")
+            self.bufferbar.setText(f"{Sender.getBufferFill(self:3.0f)}%")
 
             if self._selectI >= 0 and self._paths:
                 while self._selectI <= self._gcount and self._selectI < len(


### PR DESCRIPTION
Previous codefactor push changed the text formatting of the buffer bar status text to a floating point number.  Added formatting to force number to be displayed as a integer whole number.

Changes to be committed:
	modified:   bCNC/bmain.py