### PR TITLE
Update TLO after Stop button is hit

### DIFF
--- a/bCNC/controllers/_GenericController.py
+++ b/bCNC/controllers/_GenericController.py
@@ -224,6 +224,7 @@ class _GenericController:
             self.master.sendGCode(G)  # restore $G
         self.master.sendGCode(f"G43.1Z{TLO}")  # restore TLO
         self.viewState()
+        self.viewParameters()
 
     # ----------------------------------------------------------------------
     def displayState(self, state):


### PR DESCRIPTION
Hitting the Stop button resets the TLO value field shows zero, however the actual TLO value sets correctly set to it's previous value. Calling self.viewParameters() updates the TLO field correctly.