### PR TITLE
Fix user button interpolation

### DIFF
--- a/bCNC/Utils.py
+++ b/bCNC/Utils.py
@@ -752,30 +752,30 @@ class UserButton(Ribbon.LabelButton):
         tkExtra.Balloon.set(self, tooltip)
 
     # ----------------------------------------------------------------------
-    def name(self):
+    def name(self, raw=False):
         try:
-            return config.get("Buttons", f"name.{int(self.button)}")
+            return config.get("Buttons", f"name.{int(self.button)}", raw=raw)
         except Exception:
             return str(self.button)
 
     # ----------------------------------------------------------------------
-    def icon(self):
+    def icon(self, raw=False):
         try:
-            return config.get("Buttons", f"icon.{int(self.button)}")
+            return config.get("Buttons", f"icon.{int(self.button)}", raw=raw)
         except Exception:
             return None
 
     # ----------------------------------------------------------------------
-    def tooltip(self):
+    def tooltip(self, raw=False):
         try:
-            return config.get("Buttons", f"tooltip.{int(self.button)}")
+            return config.get("Buttons", f"tooltip.{int(self.button)}", raw=raw)
         except Exception:
             return ""
 
     # ----------------------------------------------------------------------
-    def command(self):
+    def command(self, raw=False):
         try:
-            return config.get("Buttons", f"command.{int(self.button)}")
+            return config.get("Buttons", f"command.{int(self.button)}", raw=raw)
         except Exception:
             return ""
 
@@ -863,15 +863,15 @@ class UserButtonDialog(Toplevel):
         Button(f, text=_("Ok"), command=self.ok).pack(side=RIGHT)
 
         # Set variables
-        self.name.insert(0, self.button.name())
-        self.tooltip.insert(0, self.button.tooltip())
-        icon = self.button.icon()
+        self.name.insert(0, self.button.name(raw=True))
+        self.tooltip.insert(0, self.button.tooltip(raw=True))
+        icon = self.button.icon(raw=True)
         if icon is None:
             self.iconCombo.set(UserButtonDialog.NONE)
         else:
             self.iconCombo.set(icon)
         self.icon["image"] = icons.get(icon, "")
-        self.command.insert("1.0", self.button.command())
+        self.command.insert("1.0", self.button.command(raw=True))
 
         # Wait action
         self.wait_visibility()


### PR DESCRIPTION
# Actual behavior
- Because config parser is [created with default values](https://github.com/vlachoudis/bCNC/blob/master/bCNC/Utils.py#L143), [BasicInterpolation](https://docs.python.org/3/library/configparser.html#configparser.BasicInterpolation) is enabled, which means we can refer to config values when editing a user defined button.
- For example, if you define `slow = 5000` in the `[Buttons]` section, you could use `M3S%(slow)s` in the `command` and it would be interpolated to `M3S5000`. This is limited because you can't interpolate values from outside `[Buttons]` section, but this is how it's implemented actually.
- It means that if you want to include a `%` text somewhere, for example you want to name your button `Set laser power to 5%` you have to double the `%` like this : `Set laser power to 5%%` or **Python will raise an Exception**.
# Problem
When you open the button edition dialog, values populated from the config are interpoled. This means you lose your double `%%`. `Set laser power to 5%%` becomes `Set laser power to 5%` again, and you can't validate unless you manually double all the `%` again before clicking OK.
# Steps to reproduce
- Edit a button
- Name your button `Set laser power to 5%%` and click OK
- Edit the button again
- click OK
- and Exception is raised and the dialog is not closed
# Proposed fix
Load raw values from the config. This way the values remains exactly as there were typed in first place.
# Alternatives
- Totally disable interpolation by using `config = configparser.ConfigParser(interpolation=None)`. Maybe interpolation is an unneeded feature here ? It would allow to input `%` without escaping it.
# Opening
We could switch to [ExtendedInterpolation](https://docs.python.org/3/library/configparser.html#configparser.ExtendedInterpolation). This type of interpolation does not use `%` and **gives more power because it allows accessing other sections of the config**. For example you could use the value of `CNC.feedmax_z` in a command or whatever. The problem here is that this type of interpolation use `$` instead of `%`, and you would have to double all the `$`, which would be boring for existing configs. Anyway the proposed fix is still valid.
