### PR TITLE
Fix edge case in DXF import, closes #1499

### DIFF
--- a/bCNC/lib/dxf.py
+++ b/bCNC/lib/dxf.py
@@ -46,6 +46,15 @@ __email__ = "Vasilis.Vlachoudis@cern.ch"
 EPS = 0.000001
 EPS2 = EPS**2
 
+# For each entity type, list the tags having multiple entries
+# See https://help.autodesk.com/view/OARX/2023/ENU/?guid=GUID-7D07C886-FD1D-4A0C-A7AB-B4D21F18E484
+MULTIPLE_ENTRIES_TAGS = {
+    "LEADER": (10,),
+    "LWPOLYLINE": (10, 20, 40, 41, 42),
+    "MLINE": (11, 12, 13),
+    "SPLINE": (10, 11, 20, 21, 30, 31, 40)
+}
+
 # Just to avoid repeating errors
 errors = {}
 
@@ -58,6 +67,11 @@ def error(msg):
     else:
         sys.stderr.write(msg)
         errors[msg] = 1
+
+
+# -----------------------------------------------------------------------------
+def is_multiple_entries_tag(entityType, tag):
+    return tag in MULTIPLE_ENTRIES_TAGS.get(entityType, ())
 
 
 # =============================================================================
@@ -640,11 +654,9 @@ class Entity(dict):
                     # Replace last value
                     self[42][-1] = value
                 elif existing is None:
-                    self[tag] = value
+                    self[tag] = [value] if is_multiple_entries_tag(self.type, tag) else value
                 elif isinstance(existing, list):
                     existing.append(value)
-                else:
-                    self[tag] = [existing, value]
                 # Synchronize optional bulge with number of vertices
                 if tag == 10 and self.type == "LWPOLYLINE":
                     bulge = self.get(42)


### PR DESCRIPTION
# Introduction

According to [DXF Reference](https://help.autodesk.com/view/OARX/2023/ENU/?guid=GUID-7D07C886-FD1D-4A0C-A7AB-B4D21F18E484), entities have **group codes** (which are named **tags** in bCNC). Some of the group codes, on some entities, represent list values. For example the doc for [LWPOLYLINE entity](https://help.autodesk.com/view/OARX/2023/ENU/?guid=GUID-748FC305-F3F2-4F74-825A-61F04D757A50) on group code 10 says "Vertex coordinates (in OCS), multiple entries; one entry for each vertex".

# Problem

Current implementation in bCNC is lazy, it doesn't know if the value should be a list or not :
- the first time a tag is encountered, bCNC stores the value as a scalar
- the second time this tag is encountered, bCNC replaces the existing scalar with a list of [existing, new] values
- then if the tag is encountered again, bCNC appends new values to the stored list

The problem exhibited in [xmas_w_logo.dxf.zip](https://github.com/vlachoudis/bCNC/files/5721326/xmas_w_logo.dxf.zip) is that the lazy implementation doesn't work when the group contains a single entry : the stored value has no opportunity to be converted to a list. It remains a scalar, a `float` in this case, then an Exception is raised when bCNC tries to access sub elements as if it was a list.

# Proposed fix

- Add a static list of tags for which we know we should receive a list.
- Correctly initialise a list as soon as the first entry is read.
- Remove code converting from scalar to list

Fixes loading of the example file attached in [xmas_w_logo.dxf.zip](https://github.com/vlachoudis/bCNC/files/5721326/xmas_w_logo.dxf.zip) from #1499