### PR TITLE
Disable ConfigParser interpolation

### DIFF
--- a/bCNC/Utils.py
+++ b/bCNC/Utils.py
@@ -140,7 +140,7 @@ LANGUAGES = {
 
 icons = {}
 images = {}
-config = configparser.ConfigParser()
+config = configparser.ConfigParser(interpolation=None)
 print(
     "new-config", __prg__, config
 )  # This is here to debug the fact that config is sometimes instantiated twice


### PR DESCRIPTION
As discussed [here](https://github.com/vlachoudis/bCNC/pull/1817#issuecomment-1455155475), in bCNC the interpolation of config variables seems to be a side effect rather than a feature. Currently, the interpolation makes user buttons barely usable. Let's disable it for now.
