### PR TITLE
Stick to working version of tkinter-standalone

### DIFF
--- a/flatpak/io.github.bcnc.json
+++ b/flatpak/io.github.bcnc.json
@@ -88,7 +88,8 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/iwalton3/tkinter-standalone"
+          "url": "https://github.com/iwalton3/tkinter-standalone",
+          "commit": "20950173c51b7d4b67cfb5d765d41c2600f9bee3"
         }
       ]
     }


### PR DESCRIPTION
Fixes the following flatpak build error:
 clinic/_tkinter.c.h:544:20: error: initializer element is not constant
 544 |     {"dooneevent", _PyCFunction_CAST(_tkinter_tkapp_dooneevent), \
 METH_FASTCALL, _tkinter_tkapp_dooneevent__doc__},

by sticking to the last working version.

The very latest revision is an adjustment for python 3.11 and does not compile with python 3.10.