### PR TITLE
Camera improvements

### DIFF
--- a/bCNC/ToolsPage.py
+++ b/bCNC/ToolsPage.py
@@ -612,7 +612,7 @@ class Camera(_Base):
     def __init__(self, master):
         _Base.__init__(self, master, "Camera")
         self.variables = [
-            ("aligncam", "int", 0, _("Align Camera")),
+            ("aligncam", "str", 0, _("Align Camera")),  # value can be int or str
             ("aligncam_width", "int", 0, _("Align Camera Width")),
             ("aligncam_height", "int", 0, _("Align Camera Height")),
             ("aligncam_angle", "0,90,180,270", 0, _("Align Camera Angle")),

--- a/bCNC/Utils.py
+++ b/bCNC/Utils.py
@@ -312,6 +312,19 @@ def getBool(section, name, default=False):
 
 
 # -----------------------------------------------------------------------------
+def getIntOrStr(section, name, default=0):
+    global config
+    try:
+        value = config.get(section, name)
+    except Exception:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+# -----------------------------------------------------------------------------
 # Return a font from a string
 # -----------------------------------------------------------------------------
 def makeFont(name, value=None):


### PR DESCRIPTION
* 'aligncam' and 'webcam' config settings can now be a string instead of an integer.  This is needed to access video sources that OpenCV cannot auto-detect, and therefore does not assign an index number for.  (My personal use-case is a WiFi camera, intended for use on a drone, that is accessed via a rtmp:// URL.  It might also be useful as a stable identifier for a particular camera, that remains valid even if other cameras are connected or disconnected, but I don't know a general way to determine the string for an indexed camera.)
* Added 'PREFIX_threaded' config option for each camera: if 1, the camera is read continuously in a background thread, and the most recent image is used when one is requested.  This is needed for cameras that return the oldest available frame, rather than the newest, when read less frequently than their natural FPS rate.  (Without this option, my WiFi camera has about 15 seconds of lag, making it utterly unusable.)