### PR TITLE
Corrected camera index reading from config when multiple webcams

### DIFF
--- a/bCNC/Camera.py
+++ b/bCNC/Camera.py
@@ -39,7 +39,7 @@ class Camera:
         if cv is None:
             return
         self.prefix = prefix
-        self.idx = Utils.getInt("Camera", prefix)
+        self.idx = Utils.getInt("Camera", "webcam")
         self.props = self._getCameraProperties(prefix)
         self.camera = None
         self.image = None


### PR DESCRIPTION
Corrected camera index reading from config when multiple webcams
It was opening device index 0, regardless saved setting.

#1666 