### PR TITLE
Get rid of temporary files for web pendant

### DIFF
--- a/bCNC/Camera.py
+++ b/bCNC/Camera.py
@@ -196,6 +196,10 @@ class Camera:
     def save(self, filename):
         cv.imwrite(filename, self.original)
 
+    def jpg(self):
+        s, jpg = cv.imencode(".jpg", self.image)
+        return jpg if s else None
+
     # -----------------------------------------------------------------------
     # Rotate image in steps of 90deg
     # -----------------------------------------------------------------------

--- a/bCNC/Pendant.py
+++ b/bCNC/Pendant.py
@@ -168,15 +168,14 @@ class Pendant(httpserver.BaseHTTPRequestHandler):
                 return
             if Pendant.camera is None:
                 Pendant.camera = Camera.Camera("webcam")
-                Pendant.camera.start()
+                if not Pendant.camera.start():
+                    Pendant.camera = None
 
             if Pendant.camera.read():
-                Pendant.camera.save("camera.jpg")
                 try:
-                    f = open("camera.jpg","rb")
-                    self.do_HEAD(200, content="image/jpeg", cl=self.get_file_size(f))
-                    self.wfile.write(f.read())
-                    f.close()
+                    img = Pendant.camera.jpg()
+                    self.do_HEAD(200, content="image/jpeg", cl=len(img))
+                    self.wfile.write(img)
                 except Exception:
                     pass
         else:


### PR DESCRIPTION
Both OpenCV (for the camera) as well as PIL.Image (for the Canvas) can work with buffer like objects, which then can be immediately written out by the webserver code.