### PR TITLE
Update org.freedesktop.Platform to 24.08

### DIFF
--- a/flatpak/io.github.bcnc.json
+++ b/flatpak/io.github.bcnc.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.bcnc",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "22.08",
+  "runtime-version": "24.08",
   "sdk": "org.freedesktop.Sdk",
   "build-options": {
     "build-args": [


### PR DESCRIPTION
Update due to flatpack's complaints:
 Info: org.freedesktop.Platform is end-of-life,
 with reason: org.freedesktop.Platform 22.08 is no longer
 receiving fixes and security updates.
 Please update to a supported runtime version.