### PR TITLE
Fix dynamic loading of controllers and plugins in Python 3.13

### DIFF
--- a/bCNC/Sender.py
+++ b/bCNC/Sender.py
@@ -130,8 +130,8 @@ class Sender:
             if name[0] == "_":
                 continue
             try:
-                exec(f"import {name}")
-                self.controllers[name] = eval(f"{name}.Controller(self)")
+                package = __import__(name, globals(), locals(), [], 0)
+                self.controllers[name] = package.Controller(self)
             except (ImportError, AttributeError):
                 typ, val, tb = sys.exc_info()
                 traceback.print_exception(typ, val, tb)

--- a/bCNC/ToolsPage.py
+++ b/bCNC/ToolsPage.py
@@ -1283,8 +1283,8 @@ class Tools:
         for f in glob.glob(f"{Utils.prgpath}/plugins/*.py"):
             name, ext = os.path.splitext(os.path.basename(f))
             try:
-                exec(f"import {name}")
-                tool = eval(f"{name}.Tool(self)")
+                package = __import__(name, globals(), locals(), [], 0)
+                tool = package.Tool(self)
                 self.addTool(tool)
             except (ImportError, AttributeError):
                 typ, val, tb = sys.exc_info()


### PR DESCRIPTION
This should be a fix for #1910.  Tested on both 3.13 and 3.12 on Debian Bookworm