### PR TITLE
use correct NONE to compare cameraAnchor

### DIFF
--- a/bCNC/CNCCanvas.py
+++ b/bCNC/CNCCanvas.py
@@ -1324,7 +1324,7 @@ class CNCCanvas(Canvas):
         hc //= 2
         x = w // 2  # everything on center
         y = h // 2
-        if self.cameraAnchor is None:
+        if self.cameraAnchor is NONE:
             if self._lastGantry is not None:
                 x, y = self.plotCoords([self._lastGantry])[0]
             else:


### PR DESCRIPTION
Comparison was with None, but tk.NONE is used for this variable, which are different.

This broke the "gantry" camera mode for me; with this change it works as expected.