### PR TITLE
format numbers with a sensible number of digits when setting wcs

### DIFF
--- a/bCNC/controllers/_GenericController.py
+++ b/bCNC/controllers/_GenericController.py
@@ -154,17 +154,17 @@ class _GenericController:
 
         pos = ""
         if x is not None and abs(float(x)) < 10000.0:
-            pos += "X" + str(x)
+            pos += CNC.fmt("X", float(x))
         if y is not None and abs(float(y)) < 10000.0:
-            pos += "Y" + str(y)
+            pos += CNC.fmt("Y", float(y))
         if z is not None and abs(float(z)) < 10000.0:
-            pos += "Z" + str(z)
+            pos += CNC.fmt("Z", float(z))
         if a is not None and abs(float(a)) < 10000.0:
-            pos += "A" + str(a)
+            pos += CNC.fmt("A", float(a))
         if b is not None and abs(float(b)) < 10000.0:
-            pos += "B" + str(b)
+            pos += CNC.fmt("B", float(b))
         if c is not None and abs(float(c)) < 10000.0:
-            pos += "C" + str(c)
+            pos += CNC.fmt("C", float(c))
         cmd += pos
         self.master.sendGCode(cmd)
         self.viewParameters()


### PR DESCRIPTION
This mainly affected setting the work coordinate with the mouse, which can result in numbers with lots of digits. This doesn't work with my particular controller (uCNC), but more generally always results in a very long command being shown in the UI, and is inconsistent with other code.

This does make some uses of `_wcsSet` look a bit odd:

- some places pass '"0"' strings (or empty strings), presumably to avoid being formatted as "0.0", but this is redundant if they are always converted to a float first.
- some places round numbers before calling this, but that's not necessary.

I can fix these if desired. It's also unclear what the 10000mm limit is for; looks like this was introduced in this commit d8dbd633b70a1ded4f291df86d44bd527cd1c755.