### PR TITLE
GRBL1: account for Hold sub-states in wait condition

### DIFF
--- a/bCNC/controllers/GRBL1.py
+++ b/bCNC/controllers/GRBL1.py
@@ -216,10 +216,11 @@ class Controller(_GenericGRBL):
                     break
 
         # Machine is Idle buffer is empty stop waiting and go on
+        main_state = fields[0].split(":")[0]
         if (
             self.master.sio_wait
             and not cline
-            and fields[0] not in ("Run", "Jog", "Hold")
+            and main_state not in ("Run", "Jog", "Hold")
         ):
             self.master.sio_wait = False
             self.master._gcount += 1


### PR DESCRIPTION
This fixes a problem i had in `toolChange`, where `%wait` continues too soon after a command which transitions through an idle state, which isn't recognised if it's sent as `Hold:0` or `Hold:1`.

As per my other PR, this caused an issue with uCNC, and might not with other controllers, though GRBL does apparently send `Hold:0` and `Hold:1`.