### PR TITLE
Add NixOS (nix-shell) support

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+let
+  pkgs = import <nixpkgs> {};
+in pkgs.mkShell {
+  packages = [
+    (pkgs.python3.withPackages (python-pkgs: [
+      python-pkgs.tkinter
+      python-pkgs.numpy
+      python-pkgs.svgelements
+      python-pkgs.pyserial
+      python-pkgs.pillow
+    ]))
+  ];
+}


### PR DESCRIPTION
Add a shell which facilitates development and running of bCNC on a NixOS system, or another *nix using the Nix package manager.