### PR TITLE
Update python-opencv version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "Pillow>=4.0",
         # Note there are no PyPI OpenCV packages for ARM
         # (Raspberry PI, Orange PI, etc...)
-        "opencv-python==4.5.5.62 ; "
+        "opencv-python==4.5.5.64 ; "
         + "(\"arm\" not in platform_machine) and "
         + "(\"aarch64\" not in platform_machine)"
     ],


### PR DESCRIPTION
python-opencv 4.5.5.62 has been yanked and is no longer available: https://pypi.org/project/opencv-python/4.5.5.62/

4.5.5.64 is the next version up that is still available, but not the newest version. Maybe there is interest in generally updating; the current version of python-opencv is 4.1.0.68. 

However I don't understand the implications of updating, so I stuck with recommended version.