### PR TITLE
Fix: module 'PIL.Image' has no attribute 'ANTIALIAS' in sketcher and pyrograph

### DIFF
--- a/bCNC/plugins/pyrograph.py
+++ b/bCNC/plugins/pyrograph.py
@@ -111,7 +111,7 @@ class Tool(Plugin):
             newHeight = int(divisions)
 
         # Create a thumbnail image to work faster
-        img.thumbnail((newWidth, newHeight), Image.ANTIALIAS)
+        img.thumbnail((newWidth, newHeight), Image.LANCZOS)
         newWidth, newHeight = img.size
         pixels = list(img.getdata())
 

--- a/bCNC/plugins/sketch.py
+++ b/bCNC/plugins/sketch.py
@@ -260,7 +260,7 @@ class Tool(Plugin):
         resampleRatio = 800.0 / iHeight
         img = img.resize(
             (int(iWidth * resampleRatio),
-             int(iHeight * resampleRatio)), Image.ANTIALIAS
+             int(iHeight * resampleRatio)), Image.LANCZOS
         )
         if channel == "Blue":
             img = img.convert("RGB")


### PR DESCRIPTION
Following the 10.0.0 release of PIL it no longer has the ANTIALIAS  constant hence updated the references

https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants

Also see
[Stackoverfow](https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias)