### PR TITLE
Fix import of KiCad drill files in Driller plugin

### DIFF
--- a/bCNC/plugins/driller.py
+++ b/bCNC/plugins/driller.py
@@ -112,7 +112,7 @@ class Tool(Plugin):
                                 or line.startswith("METRIC")):
                             unitinch = line.startswith("INCH")
                             decimals = 0.1 ** len(
-                                line[line.index("."): -1]
+                                line[line.find("."): -1]
                             )  # calculates the multiplier for decimal places
                         if line == "M95" or line == "%":
                             header = False


### PR DESCRIPTION
https://github.com/vlachoudis/bCNC/commit/5fdfd235322a145de7cc26bab986b92fcd1e756e claims to add support for a feature from Eagle's Excellon drill file format, which is the specification of the number of decimals for coordinates as an operand to the `METRIC` or `INCH` commands.

https://github.com/vlachoudis/bCNC/blob/5aab96b12f9f96794abfc47af661ba5fc7767d4b/bCNC/plugins/driller.py#L111-L116

Unfortunately, if this precision isn't specified, the `line.index()` call raises an error and the plugin crashes.

KiCad doesn't add precision information after `METRIC` and `INCH` commands in its drill files, so the Driller plugin crashes when importing those files.

This pull request allows for the plugin to not crash and instead process a KiCad drill file normally, assuming that the coordinates in the drill file are to be used as is.

I did test this change on my own files and it works fine. I can't tell for Eagle drill files but I'm pretty sure it's going to work since the only difference between `str.index()` and `str.find()` is that the former throws and error when the substring is not found, while the latter returns -1.