### PR TITLE
Remove unused dependency tkinter-gl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,7 @@ setup(
         # (Raspberry PI, Orange PI, etc...)
         "opencv-python==4.5.5.64 ; "
         + "(\"arm\" not in platform_machine) and "
-        + "(\"aarch64\" not in platform_machine)",
-	"tkinter-gl>=1.0"
+        + "(\"aarch64\" not in platform_machine)"
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the dependency `tkinter-gl`, introduced in 7a0838c is specified as a requirement in the `setup.py` file, when in reality it is not used.

This PR removes it from `setup.py`, which helps keeping the dependency list clean.

Hope this is helpful!

Best regards